### PR TITLE
Add missing fields in Prometheus config

### DIFF
--- a/component/prometheus.jsonnet
+++ b/component/prometheus.jsonnet
@@ -54,8 +54,10 @@ local prometheus = {
       'kubernetes.io/os': 'linux',
     },
     podMonitorNamespaceSelector+: nsSelector,
+    podMonitorSelector+: {},
     ruleNamespaceSelector+: nsSelector,
     serviceMonitorNamespaceSelector+: nsSelector,
+    serviceMonitorSelector+: {},
     ruleSelector+: {
       matchLabels: matchLabels,
     },


### PR DESCRIPTION
Add empty fields `podMonitorSelector` and `serviceMonitorSelector` to ensure all pod and servicemonitors in the selected namespaces are picked up.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
