### PR TITLE
Update kube-prometheus version locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/projectsyn/component-rancher-monitoring/compare/084a263baf909b627d2861790805ac8f7de3f580...HEAD
 [#1]: https://github.com/projectsyn/component-rancher-monitoring/pull/1
+
+### Fixed
+
+- Update kube-prometheus version locks to include recent dependency fixes ([#4]).
+
+[#4]: https://github.com/projectsyn/component-rancher-monitoring/pull/4

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,9 +4,9 @@ parameters:
 
     kube_prometheus_version:
       '1.15': 53f18a42769ea1d4bce833962a908f84069ef495
-      '1.16': 4e7440f742df31cd6da188f52ddc4e4037b81599
-      '1.17': 4e7440f742df31cd6da188f52ddc4e4037b81599
-      '1.18': f69ff3d63de17f3f52b955c3b7e0d7aff0372873
+      '1.16': 1b838d59a58522e969194daaeaac0c1709192771
+      '1.17': 1b838d59a58522e969194daaeaac0c1709192771
+      '1.18': b2b90f25b853719bebd964a6680f156e436a7efb
     cluster_kubernetes_version: '1.18'
     jsonnetfile_parameters:
       kube_prometheus_version: ${rancher_monitoring:kube_prometheus_version:${rancher_monitoring:cluster_kubernetes_version}}


### PR DESCRIPTION
The versions are set to the latest commit hash of the respective release. They now have the version of etcd-mixin pinned which was set to master before. Changes have been introduced in upstream etcd-mixin to move the libsonnet file to a different location which broke existing releases of kube-prometheus.

This includes the fixes made in:
https://github.com/prometheus-operator/kube-prometheus/pull/934
https://github.com/prometheus-operator/kube-prometheus/pull/935


<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
