### PR TITLE
Skip recording rules when adding custom annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update kube-prometheus version locks to include recent dependency fixes ([#4]).
 - Update kube-prometheus repository location ([#7])
+- Skip recording rules when adding custom annotations ([#10])
 
 [Unreleased]: https://github.com/projectsyn/component-rancher-monitoring/compare/084a263baf909b627d2861790806ac8f7de3f580...HEAD
 [#1]: https://github.com/projectsyn/component-rancher-monitoring/pull/1
@@ -28,3 +29,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#6]: https://github.com/projectsyn/component-rancher-monitoring/pull/6
 [#7]: https://github.com/projectsyn/component-rancher-monitoring/pull/7
 [#8]: https://github.com/projectsyn/component-rancher-monitoring/pull/8
+[#10]: https://github.com/projectsyn/component-rancher-monitoring/pull/10

--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -46,16 +46,22 @@ local annotateRules = {
         group {
           rules: std.map(
             function(rule)
-              local annotations =
-                defaultAnnotations +
-                if std.objectHas(rule, 'alert') && std.objectHas(customAnnotations, rule.alert) then
-                  customAnnotations[rule.alert]
-                else
-                  {};
+              // Only add custom annotations to alert rules, since recording
+              // rules cannot have annotations.
+              // We identify alert rules by the presence of the `alert` field.
+              if std.objectHas(rule, 'alert') then
+                local annotations =
+                  defaultAnnotations +
+                  if std.objectHas(customAnnotations, rule.alert) then
+                    customAnnotations[rule.alert]
+                  else
+                    {};
 
-              rule {
-                annotations+: annotations,
-              },
+                rule {
+                  annotations+: annotations,
+                }
+              else
+                rule,
             group.rules
           ),
         },


### PR DESCRIPTION
Recording rules cannot have field `annotations`, so we exclude them when adding our custom annotations. We identify recording rules by the absence of field `alert` in the rule object.

Fixes #9.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
