### PR TITLE
Federation: Exclude ingress-nginx metrics 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade kube-prometheus ([#6])
 - Upgrade Prometheus to v2.25.0 ([#11])
+- Federation: Exclude ingress-nginx metrics ([#12])
 
 ### Fixed
 
@@ -33,3 +34,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#8]: https://github.com/projectsyn/component-rancher-monitoring/pull/8
 [#10]: https://github.com/projectsyn/component-rancher-monitoring/pull/10
 [#11]: https://github.com/projectsyn/component-rancher-monitoring/pull/11
+[#12]: https://github.com/projectsyn/component-rancher-monitoring/pull/12

--- a/component/federation.jsonnet
+++ b/component/federation.jsonnet
@@ -36,7 +36,7 @@ local monitor = {
         path: '/federate',
         params: {
           'match[]': [
-            '{job!=""}',
+            '{job!="ingress-nginx-controller-metrics"}',
           ],
         },
         honorLabels: true,


### PR DESCRIPTION
~Includes #11.~ rebased

ingress-nginx metrics include request counts, error codes, latencies etc. for ALL ingress objects on the cluster. Hence, those (unused by the provided alertrules) metrics are responsible for approx. 80-90% of all data accumulated.

On our test cluster, excluding those metrics from scraping reduced the scraping duration from 53s to ~~13s~~ 5s, and memory usage from 6Gi to 4Gi.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
