### PR TITLE
Exclude ingress metrics on older Rancher versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade kube-prometheus ([#6])
 - Upgrade Prometheus to v2.25.0 ([#11])
-- Federation: Exclude ingress-nginx metrics ([#12])
+- Federation: Exclude ingress-nginx metrics ([#12]) ([#15])
 
 ### Fixed
 
@@ -35,3 +35,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#10]: https://github.com/projectsyn/component-rancher-monitoring/pull/10
 [#11]: https://github.com/projectsyn/component-rancher-monitoring/pull/11
 [#12]: https://github.com/projectsyn/component-rancher-monitoring/pull/12
+[#15]: https://github.com/projectsyn/component-rancher-monitoring/pull/15

--- a/component/federation.jsonnet
+++ b/component/federation.jsonnet
@@ -36,7 +36,7 @@ local monitor = {
         path: '/federate',
         params: {
           'match[]': [
-            '{job!="ingress-nginx-controller-metrics"}',
+            '{job!="ingress-nginx-controller-metrics",created_by_kind!="nginx-ingress-controller"}',
           ],
         },
         honorLabels: true,


### PR DESCRIPTION
Turns out on older versions of Rancher, a different mechanism to scrape the ingress-nginx metrics is used and hence the metric labels differ.

This commit also excludes "nginx-ingress-controller" metrics (their job lable is "prometheus-io-scrape", which corresponds to the `prometheus.io/scrape` annotation which is too generic to exclude).

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
