### PR TITLE
Reimplement federation with Rancher Prometheus

### DIFF
--- a/component/federation.jsonnet
+++ b/component/federation.jsonnet
@@ -10,38 +10,40 @@ local federation_interval = params.federation.interval;
 // comparison/sanity checks without parsing them, which would be overkill.
 local federation_scrape_timeout = params.federation.scrape_timeout;
 
-local monitor = {
-  apiVersion: 'monitoring.coreos.com/v1',
-  kind: 'ServiceMonitor',
-  metadata: {
-    name: 'rancher-federation',
-    namespace: namespace,
+local scrape_config = kube.Secret('additional-scrape-configs') {
+  metadata+: {
+    namespace: params.namespace,
   },
-  spec: {
-    namespaceSelector: {
-      matchNames: [
-        'cattle-prometheus',
-      ],
-    },
-    selector: {
-      matchLabels: {
-        app: 'prometheus',
-      },
-    },
-    endpoints: [
+  stringData: {
+    'prometheus-additional.yaml': std.manifestYamlDoc([
       {
-        port: 'nginx-http',
-        interval: federation_interval,
-        scrapeTimeout: federation_scrape_timeout,
-        path: '/federate',
+        job_name: 'access-prometheus',
+        honor_labels: true,
+        honor_timestamps: true,
         params: {
           'match[]': [
             '{job!="ingress-nginx-controller-metrics",created_by_kind!="nginx-ingress-controller"}',
           ],
         },
-        honorLabels: true,
+        scrape_interval: federation_interval,
+        scrape_timeout: federation_scrape_timeout,
+        metrics_path: '/federate',
+        scheme: 'http',
+        static_configs: [
+          {
+            targets: [
+              'access-prometheus.cattle-prometheus.svc.cluster.local:80',
+            ],
+          },
+        ],
+        relabel_configs: [
+          {
+            regex: 'pod_name',
+            action: 'labeldrop',
+          },
+        ],
       },
-    ],
+    ]),
   },
 };
 
@@ -76,6 +78,6 @@ local rule = {
 
 
 [
-  monitor,
+  scrape_config,
   rule,
 ]

--- a/component/prometheus.jsonnet
+++ b/component/prometheus.jsonnet
@@ -67,6 +67,10 @@ local prometheus = {
       runAsUser: 1000,
     },
     serviceAccountName: name,
+    additionalScrapeConfigs: {
+      name: 'additional-scrape-configs',
+      key: 'prometheus-additional.yaml',
+    },
   } + com.makeMergeable(params.prometheus),
 };
 


### PR DESCRIPTION
* Use the Prometheus CRD `additionalScrapeConfigs` instead of a `ServiceMonitor` to configure federation.
* Add `metric_relabeling_configs` to fix the namespace labels for metrics which already have both `namespace` and `exported_namespace` in Rancher Prometheus.

Fixes #13

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
