### PR TITLE
Make alert namespace selector configurable

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -60,6 +60,7 @@ parameters:
       scrape_timeout: '10s'
 
     alerts:
+      namespaceSelector: namespace=~"default|((kube|syn|cattle).*)"
       # List of alertnames to exclude from the final ruleset
       ignoreNames: []
       customAnnotations: {}

--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -165,7 +165,7 @@ local kp =
       kubeStateMetricsSelector: 'job="expose-kubernetes-metrics"',
       kubeletSelector: 'job="expose-kubelets-metrics"',
       nodeExporterSelector: 'job="expose-node-metrics"',
-      prefixedNamespaceSelector: 'namespace=~"default|((kube|syn|cattle).*)",',
+      namespaceSelector: params.alerts.namespaceSelector,
     },
   };
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -167,6 +167,19 @@ Configure the scrape interval and timeout for the Prometheus job which federates
 
 Users should ensure that the `scrape_timeout` is lower than the `interval`, as there's no validation logic in the component.
 
+
+== `alerts.namespaceSelector`
+
+[horizontal]
+type:: string
+default:: `namespace=~"default|((kube|syn|cattle).*)"`
+
+Namespace selector which is injected into alert rules by `kube-prometheus` (via `kubernetes-mixin`).
+
+By default, alerts for namespaced objects are only configured for namespaces which are part of Kubernetes, Rancher, or Project Syn.
+
+To fully remove the selector, set this parameter to `null`.
+
 == `alerts.ignoreNames`
 
 [horizontal]


### PR DESCRIPTION
This is necessary because the changes introduced in #19 will make the namespace selector actually work for some alerts, e.g. `KubePersistentVolumeFillingUp`.

With this change, users of the component can choose to receive alerts for a different set of namespaces than the default selector, which includes only namespaces which are part of Kubernetes, Rancher, or Project Syn.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
