### PR TITLE
Alertmanager: replace deprecated attributes

### DIFF
--- a/component/alertmanager.jsonnet
+++ b/component/alertmanager.jsonnet
@@ -34,8 +34,7 @@ local alertmanager = {
     labels: labels,
   },
   spec+: {
-    baseImage: params.images.alertmanager.image,
-    tag: params.images.alertmanager.tag,
+    image: params.images.alertmanager.image + ':' + params.images.alertmanager.tag,
     nodeSelector+: {
       'kubernetes.io/os': 'linux',
     },


### PR DESCRIPTION
`baseImage` and `tag` are deprecated in favor of `image`.

From logs:

    level=warn ts=2021-05-31T08:46:54.592591902Z caller=operator.go:484 component=alertmanageroperator msg="alertmanager key=syn-synsights/platform, field spec.baseImage is deprecated, 'spec.image' field should be used instead"
    level=warn ts=2021-05-31T08:46:54.592645194Z caller=operator.go:487 component=alertmanageroperator msg="alertmanager key=syn-synsights/platform, field spec.tag is deprecated, 'spec.image' field should be used instead"

Also see 59dc617633dc77b62f8c5dedf402316345d3ea90

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
