### PR TITLE
Fix `KubeStorageClassFillingUp` alert rule expressions

### DIFF
--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -204,8 +204,8 @@ local additionalRules = {
             // It will filter only shared storage classes and take the minimum (They should all have the same available space)
             expr: (
               'min by (storageclass)'
-              + '(kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes < 0.03'
-              + '*on(persistentvolumeclaim, namespace) group_left(storageclass) kube_persistentvolumeclaim_info{storageclass="%s"})'
+              + '((kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes) < 0.03)'
+              + '*on(persistentvolumeclaim, namespace) group_left(storageclass) kube_persistentvolumeclaim_info{storageclass="%s"}'
             ) % params.alerts.sharedStorageClass,
             'for': '1m',
             labels: {
@@ -229,10 +229,10 @@ local additionalRules = {
             // It will filter only shared storage classes and take the minimum (They should all have the same available space)
             expr: (
               'min by (storageclass) ('
-              + '(kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes < 0.15'
-              + 'and'
+              + '(kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes) < 0.15'
+              + ' and '
               + 'predict_linear(kubelet_volume_stats_available_bytes[6h], 4 * 24 * 3600) < 0)'
-              + '*on(persistentvolumeclaim, namespace) group_left(storageclass) kube_persistentvolumeclaim_info{storageclass="%s"})'
+              + '*on(persistentvolumeclaim, namespace) group_left(storageclass) kube_persistentvolumeclaim_info{storageclass="%s"}'
             ) % params.alerts.sharedStorageClass,
             'for': '1h',
             labels: {


### PR DESCRIPTION
Fix wrong rules. They cannot be parsed by admissionwebhook

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
