### PR TITLE
Adjust Rancher federation to keep `namespace` label if it is correct

### DIFF
--- a/component/federation.jsonnet
+++ b/component/federation.jsonnet
@@ -56,6 +56,9 @@ local scrape_config = kube.Secret('additional-scrape-configs') {
             action: 'labeldrop',
             regex: 'namespace',
           },
+          // replace value of label namespace with value of label
+          // exported_namespace if label namespace contained
+          // "cattle-prometheus".
           {
             action: 'replace',
             regex: 'cattle-prometheus;(.*)',
@@ -64,6 +67,17 @@ local scrape_config = kube.Secret('additional-scrape-configs') {
               '__tmp_namespace',
               'exported_namespace',
             ],
+            target_label: 'namespace',
+          },
+          // Put back original namespace label otherwise.
+          {
+            action: 'replace',
+            source_labels: [
+              'exported_namespace',
+              '__tmp_namespace',
+            ],
+            regex: ';(.*)',
+            replacement: '$1',
             target_label: 'namespace',
           },
           {


### PR DESCRIPTION
We implemented relabeling configs to ensure all federated metrics have the correct `namespace` label in #19. However, the relabeling config provided in that PR drops the original `namespace` label for metrics which don't need fixing.

This commit adds an extra relabeling step to make sure the original namespace label is put back, if it was correct.

Fixes #26

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
