### PR TITLE
Fix federation with Rancher monitoring V2

### DIFF
--- a/component/federation.jsonnet
+++ b/component/federation.jsonnet
@@ -22,7 +22,7 @@ local scrape_config = kube.Secret('additional-scrape-configs') {
         honor_timestamps: true,
         params: {
           'match[]': [
-            '{job!="ingress-nginx-controller-metrics",created_by_kind!="nginx-ingress-controller"}',
+            '{__name__=~"[^:]*",job!="ingress-nginx-controller-metrics",created_by_kind!="nginx-ingress-controller"}',
           ],
         },
         scrape_interval: federation_interval,

--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -252,7 +252,7 @@ local additionalRules = {
   },
 };
 
-local kp =
+local commonkp =
   (import 'kube-prometheus/kube-prometheus.libsonnet') +
   (import 'kube-prometheus/kube-prometheus-managed-cluster.libsonnet') +
   (import 'kubernetes-mixin/alerts/add-runbook-links.libsonnet') +
@@ -272,13 +272,24 @@ local kp =
         name: params.alertmanagerInstance,
       },
 
-      prometheusOperatorSelector: 'job="expose-operator-metrics",namespace="cattle-prometheus"',
-      kubeApiserverSelector: 'job="kubernetes"',
-      kubeStateMetricsSelector: 'job="expose-kubernetes-metrics"',
-      kubeletSelector: 'job="expose-kubelets-metrics"',
-      nodeExporterSelector: 'job="expose-node-metrics"',
       namespaceSelector: params.alerts.namespaceSelector,
     },
   };
+
+local kp =
+  commonkp +
+  if params.rancher_monitoring_version == 'v1' then
+    {
+      _config+:: {
+        prometheusOperatorSelector: 'job="expose-operator-metrics",namespace="cattle-prometheus"',
+        kubeApiserverSelector: 'job="kubernetes"',
+        kubeStateMetricsSelector: 'job="expose-kubernetes-metrics"',
+        kubeletSelector: 'job="expose-kubelets-metrics"',
+        nodeExporterSelector: 'job="expose-node-metrics"',
+      },
+    }
+  else
+    {
+    };
 
 kp.prometheus.rules


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist


<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->
Rancher monitoring V2 uses a newer version of prometheus.
The default job names were updated and the selectors do not match anymore. Use the default selectors for monitoring V2, because they are correct.

Rancher monitoring V2 also comes with its own recording rules. If those are federated, a lot of metrics are dropped, because of timestamps are out-of-order errors.
Our prometheus has similar recording rules and calculates the metrics too. This results in duplicate or out-of-order errors.
Just ignoring the values from Rancher keeps the Rancher monitoring working as provided by Rancher and does not produce any errors on our side.


- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
