### PR TITLE
Append _id to external labels

### DIFF
--- a/component/prometheus.jsonnet
+++ b/component/prometheus.jsonnet
@@ -36,8 +36,8 @@ local prometheus = {
   },
   spec: {
     externalLabels: {
-      tenant: inv.parameters.cluster.tenant,
-      cluster: inv.parameters.cluster.name,
+      tenant_id: inv.parameters.cluster.tenant,
+      cluster_id: inv.parameters.cluster.name,
     },
     alerting+: {
       alertmanagers+: [


### PR DESCRIPTION
This aligns component-rancher-monitoring with
component-openshift4-monitoring and facilitates default configurations
for both components.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
