### PR TITLE
Only federate metrics we're interested in

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -63,9 +63,30 @@ parameters:
         group_interval: 5s
         repeat_interval: 10m
 
+    =_federation_job_map:
+      v1:
+        - expose-kubelets-metrics
+        - expose-kubernetes-metrics
+        - expose-node-metrics
+        - expose-prometheus-metrics
+        - kubernetes
+
+      v2:
+        - apiserver
+        - coredns
+        - kube-controller-manager
+        - kube-etcd
+        - kube-proxy
+        - kube-scheduler
+        - kube-state-metrics
+        - kubelet
+        - node-exporter
+        - rancher-monitoring-prometheus
+
     federation:
       interval: '10s'
       scrape_timeout: '10s'
+      jobs: ${rancher_monitoring:_federation_job_map:${rancher_monitoring:rancher_monitoring_version}}
 
     alerts:
       namespaceSelector: namespace=~"default|((kube|syn|cattle).*)"

--- a/component/federation.jsonnet
+++ b/component/federation.jsonnet
@@ -21,7 +21,7 @@ local scrape_config = kube.Secret('additional-scrape-configs') {
         honor_labels: true,
         honor_timestamps: true,
         params: {
-          'match[]': [ std.format('{__name__=~"[^:]+",job="%s"}', job) for job in params.federation.jobs ],
+          'match[]': [ std.format('{__name__=~"[^:]+",job="%s",alertname=""}', job) for job in params.federation.jobs ],
         },
         scrape_interval: federation_interval,
         scrape_timeout: federation_scrape_timeout,

--- a/component/federation.jsonnet
+++ b/component/federation.jsonnet
@@ -21,9 +21,7 @@ local scrape_config = kube.Secret('additional-scrape-configs') {
         honor_labels: true,
         honor_timestamps: true,
         params: {
-          'match[]': [
-            '{__name__=~"[^:]*",job!="ingress-nginx-controller-metrics",created_by_kind!="nginx-ingress-controller"}',
-          ],
+          'match[]': [ std.format('{__name__=~"[^:]+",job="%s"}', job) for job in params.federation.jobs ],
         },
         scrape_interval: federation_interval,
         scrape_timeout: federation_scrape_timeout,


### PR DESCRIPTION
The goals of this PR are

* to reduce scrape times
* reduce prometheus resource usage

by only scraping metrics we're actually remotely interested in