### PR TITLE
Determine import path for `add-runbook-links.libsonnet` based on cluster version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         instance:
           - defaults
+          - kubernetes-1.21
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -48,6 +49,7 @@ jobs:
       matrix:
         instance:
           - defaults
+          - kubernetes-1.21
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/.sync.yml
+++ b/.sync.yml
@@ -14,3 +14,4 @@ docs/antora.yml:
     key: instance
     entries:
       - defaults
+      - kubernetes-1.21

--- a/component/rules.jsonnet
+++ b/component/rules.jsonnet
@@ -252,8 +252,21 @@ local additionalRules = {
   },
 };
 
+local k8s_version =
+  local versionparts = std.split(params.cluster_kubernetes_version, '.');
+  assert std.length(versionparts) >= 2 : 'Unable to parse K8s version';
+  {
+    major: std.parseInt(versionparts[0]),
+    minor: std.parseInt(versionparts[1]),
+  };
+
 local common_mixins =
-  (import 'kubernetes-mixin/alerts/add-runbook-links.libsonnet') +
+  (
+    if k8s_version.minor <= 20 then
+      import 'kubernetes-mixin/alerts/add-runbook-links.libsonnet'
+    else
+      import 'kubernetes-mixin/lib/add-runbook-links.libsonnet'
+  ) +
   alterRules +
   annotateRules +
   filterRules;

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,1 +1,2 @@
-
+parameters:
+  rancher_monitoring: {}

--- a/tests/golden/kubernetes-1.21/rancher-monitoring/rancher-monitoring/00_namespace.yaml
+++ b/tests/golden/kubernetes-1.21/rancher-monitoring/rancher-monitoring/00_namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    SYNMonitoring: main
+    name: syn-rancher-monitoring
+  name: syn-rancher-monitoring

--- a/tests/golden/kubernetes-1.21/rancher-monitoring/rancher-monitoring/01_prometheus.yaml
+++ b/tests/golden/kubernetes-1.21/rancher-monitoring/rancher-monitoring/01_prometheus.yaml
@@ -1,0 +1,169 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: platform
+    app.kubernetes.io/managed-by: syn
+    app.kubernetes.io/name: prometheus
+    name: prometheus-platform
+  name: prometheus-platform
+  namespace: syn-rancher-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: platform
+    app.kubernetes.io/managed-by: syn
+    app.kubernetes.io/name: prometheus
+    name: prometheus-platform
+  name: prometheus-platform
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: platform
+    app.kubernetes.io/managed-by: syn
+    app.kubernetes.io/name: prometheus
+    name: prometheus-platform
+  name: prometheus-platform
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-platform
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-platform
+    namespace: syn-rancher-monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  labels:
+    app.kubernetes.io/instance: platform
+    app.kubernetes.io/managed-by: syn
+    app.kubernetes.io/name: prometheus
+  name: prometheus-platform
+  namespace: syn-rancher-monitoring
+spec:
+  additionalScrapeConfigs:
+    key: prometheus-additional.yaml
+    name: additional-scrape-configs
+  alerting:
+    alertmanagers:
+      - name: alertmanager-platform
+        namespace: syn-rancher-monitoring
+        port: web
+  evaluationInterval: 5s
+  externalLabels:
+    cluster_id: c-green-test-1234
+    tenant_id: t-silent-test-1234
+  image: quay.io/prometheus/prometheus:v2.25.0@sha256:fd8b3c4c7ced91cbe96aa8a8dd4d02aa5aff7aefdaf0e579486127745c758c27
+  nodeSelector:
+    kubernetes.io/os: linux
+  podMonitorNamespaceSelector:
+    matchLabels:
+      SYNMonitoring: main
+  podMonitorSelector: {}
+  replicas: 1
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 6Gi
+    requests:
+      cpu: 1000m
+      memory: 2Gi
+  retention: 24h
+  ruleNamespaceSelector:
+    matchLabels:
+      SYNMonitoring: main
+  ruleSelector:
+    matchLabels:
+      prometheus: platform
+      role: alert-rules
+  scrapeInterval: 10s
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
+  serviceAccountName: prometheus-platform
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      SYNMonitoring: main
+  serviceMonitorSelector: {}
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+        storageClassName: fast
+  version: v2.25.0
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    prometheus: platform
+    role: alert-rules
+  name: prometheus-platform
+  namespace: syn-rancher-monitoring
+spec:
+  endpoints:
+    - interval: 30s
+      port: web
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: platform
+      app.kubernetes.io/managed-by: syn
+      app.kubernetes.io/name: prometheus
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: platform
+    app.kubernetes.io/managed-by: syn
+    app.kubernetes.io/name: prometheus
+    name: prometheus-platform
+  name: prometheus-platform
+  namespace: syn-rancher-monitoring
+spec:
+  ports:
+    - name: web
+      port: 9090
+      targetPort: web
+  selector:
+    app: prometheus
+    prometheus: prometheus-platform
+  sessionAffinity: ClientIP
+  type: ClusterIP

--- a/tests/golden/kubernetes-1.21/rancher-monitoring/rancher-monitoring/02_alertmanager.yaml
+++ b/tests/golden/kubernetes-1.21/rancher-monitoring/rancher-monitoring/02_alertmanager.yaml
@@ -1,0 +1,90 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
+metadata:
+  labels:
+    app.kubernetes.io/instance: platform
+    app.kubernetes.io/managed-by: syn
+    app.kubernetes.io/name: alertmanager
+  name: platform
+  namespace: syn-rancher-monitoring
+spec:
+  image: quay.io/prometheus/alertmanager:v0.18.0
+  logLevel: info
+  nodeSelector:
+    kubernetes.io/os: linux
+  replicas: 1
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
+  serviceAccountName: alertmanager-platform
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: platform
+    app.kubernetes.io/managed-by: syn
+    app.kubernetes.io/name: alertmanager
+    name: alertmanager-platform
+  name: alertmanager-platform
+  namespace: syn-rancher-monitoring
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: platform
+    app.kubernetes.io/managed-by: syn
+    app.kubernetes.io/name: alertmanager
+    name: alertmanager-platform
+  name: alertmanager-platform
+  namespace: syn-rancher-monitoring
+spec:
+  ports:
+    - name: web
+      port: 9093
+      targetPort: web
+  selector:
+    alertmanager: platform
+    app: alertmanager
+  sessionAffinity: ClientIP
+  type: ClusterIP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/instance: platform
+    app.kubernetes.io/managed-by: syn
+    app.kubernetes.io/name: alertmanager
+  name: alertmanager-platform
+  namespace: syn-rancher-monitoring
+spec:
+  endpoints:
+    - interval: 30s
+      port: web
+  selector:
+    matchLabels:
+      alertmanager: platform
+      app: alertmanager
+---
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: platform
+    app.kubernetes.io/managed-by: syn
+    app.kubernetes.io/name: alertmanager
+    name: alertmanager-platform
+  name: alertmanager-platform
+  namespace: syn-rancher-monitoring
+stringData:
+  alertmanager.yaml: "\"receivers\":\n- \"name\": \"devnull\"\n\"route\":\n  \"group_interval\"\
+    : \"5s\"\n  \"group_wait\": \"0s\"\n  \"receiver\": \"devnull\"\n  \"repeat_interval\"\
+    : \"10m\""
+type: Opaque

--- a/tests/golden/kubernetes-1.21/rancher-monitoring/rancher-monitoring/10_federation.yaml
+++ b/tests/golden/kubernetes-1.21/rancher-monitoring/rancher-monitoring/10_federation.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: additional-scrape-configs
+  name: additional-scrape-configs
+  namespace: syn-rancher-monitoring
+stringData:
+  prometheus-additional.yaml: "- \"honor_labels\": true\n  \"honor_timestamps\": true\n\
+    \  \"job_name\": \"access-prometheus\"\n  \"metric_relabel_configs\":\n  - \"\
+    action\": \"labeldrop\"\n    \"regex\": \"prometheus_replica\"\n  - \"action\"\
+    : \"replace\"\n    \"source_labels\":\n    - \"namespace\"\n    \"target_label\"\
+    : \"__tmp_namespace\"\n  - \"action\": \"labeldrop\"\n    \"regex\": \"namespace\"\
+    \n  - \"action\": \"replace\"\n    \"regex\": \"cattle-(prometheus|monitoring-system);(.*)\"\
+    \n    \"replacement\": \"$2\"\n    \"source_labels\":\n    - \"__tmp_namespace\"\
+    \n    - \"exported_namespace\"\n    \"target_label\": \"namespace\"\n  - \"action\"\
+    : \"replace\"\n    \"regex\": \";(.*)\"\n    \"replacement\": \"$1\"\n    \"source_labels\"\
+    :\n    - \"exported_namespace\"\n    - \"__tmp_namespace\"\n    \"target_label\"\
+    : \"namespace\"\n  - \"action\": \"labeldrop\"\n    \"regex\": \"(__tmp|exported)_namespace\"\
+    \n  \"metrics_path\": \"/federate\"\n  \"params\":\n    \"match[]\":\n    - \"\
+    {__name__=~\\\"[^:]+\\\",job=\\\"expose-kubelets-metrics\\\",alertname=\\\"\\\"\
+    }\"\n    - \"{__name__=~\\\"[^:]+\\\",job=\\\"expose-kubernetes-metrics\\\",alertname=\\\
+    \"\\\"}\"\n    - \"{__name__=~\\\"[^:]+\\\",job=\\\"expose-node-metrics\\\",alertname=\\\
+    \"\\\"}\"\n    - \"{__name__=~\\\"[^:]+\\\",job=\\\"expose-prometheus-metrics\\\
+    \",alertname=\\\"\\\"}\"\n    - \"{__name__=~\\\"[^:]+\\\",job=\\\"kubernetes\\\
+    \",alertname=\\\"\\\"}\"\n  \"scheme\": \"http\"\n  \"scrape_interval\": \"10s\"\
+    \n  \"scrape_timeout\": \"10s\"\n  \"static_configs\":\n  - \"targets\":\n   \
+    \ - \"access-prometheus.cattle-prometheus.svc.cluster.local:80\""
+type: Opaque
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: platform
+    role: alert-rules
+  name: rancher-federation
+  namespace: syn-rancher-monitoring
+spec:
+  groups:
+    - name: rancher-federation
+      rules:
+        - alert: rancher_federation_down
+          annotations:
+            message: Scraping metrics from Rancher cluster monitoring is failing.
+          expr: min_over_time(up{job="access-prometheus"}[1m]) == 0
+          for: 180s
+          labels:
+            severity: critical

--- a/tests/golden/kubernetes-1.21/rancher-monitoring/rancher-monitoring/rules/00_kube-prometheus.yaml
+++ b/tests/golden/kubernetes-1.21/rancher-monitoring/rancher-monitoring/rules/00_kube-prometheus.yaml
@@ -1,0 +1,2332 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.1.1
+    prometheus: platform
+    role: alert-rules
+  name: platform-kube-state-metrics-rules
+  namespace: syn-rancher-monitoring
+spec:
+  groups:
+    - name: kube-state-metrics
+      rules:
+        - alert: KubeStateMetricsListErrors
+          annotations:
+            description: kube-state-metrics is experiencing errors at an elevated
+              rate in list operations. This is likely causing it to not be able to
+              expose metrics about Kubernetes objects correctly or at all.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatemetricslisterrors
+            summary: kube-state-metrics is experiencing errors in list operations.
+            syn_component: rancher-monitoring
+          expr: "(sum(rate(kube_state_metrics_list_total{job=\"expose-kubernetes-metrics\"\
+            ,result=\"error\"}[5m]))\n  /\nsum(rate(kube_state_metrics_list_total{job=\"\
+            expose-kubernetes-metrics\"}[5m])))\n> 0.01\n"
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeStateMetricsWatchErrors
+          annotations:
+            description: kube-state-metrics is experiencing errors at an elevated
+              rate in watch operations. This is likely causing it to not be able to
+              expose metrics about Kubernetes objects correctly or at all.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatemetricswatcherrors
+            summary: kube-state-metrics is experiencing errors in watch operations.
+            syn_component: rancher-monitoring
+          expr: "(sum(rate(kube_state_metrics_watch_total{job=\"expose-kubernetes-metrics\"\
+            ,result=\"error\"}[5m]))\n  /\nsum(rate(kube_state_metrics_watch_total{job=\"\
+            expose-kubernetes-metrics\"}[5m])))\n> 0.01\n"
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeStateMetricsShardingMismatch
+          annotations:
+            description: kube-state-metrics pods are running with different --total-shards
+              configuration, some Kubernetes objects may be exposed multiple times
+              or not exposed at all.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatemetricsshardingmismatch
+            summary: kube-state-metrics sharding is misconfigured.
+            syn_component: rancher-monitoring
+          expr: 'stdvar (kube_state_metrics_total_shards{job="expose-kubernetes-metrics"})
+            != 0
+
+            '
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeStateMetricsShardsMissing
+          annotations:
+            description: kube-state-metrics shards are missing, some Kubernetes objects
+              are not being exposed.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatemetricsshardsmissing
+            summary: kube-state-metrics shards are missing.
+            syn_component: rancher-monitoring
+          expr: "2^max(kube_state_metrics_total_shards{job=\"expose-kubernetes-metrics\"\
+            }) - 1\n  -\nsum( 2 ^ max by (shard_ordinal) (kube_state_metrics_shard_ordinal{job=\"\
+            expose-kubernetes-metrics\"}) )\n!= 0\n"
+          for: 15m
+          labels:
+            severity: critical
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 1.2.2
+    prometheus: platform
+    role: alert-rules
+  name: platform-node-exporter-rules
+  namespace: syn-rancher-monitoring
+spec:
+  groups:
+    - name: node-exporter
+      rules:
+        - alert: NodeFilesystemSpaceFillingUp
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available space left and is
+              filling up.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemspacefillingup
+            summary: Filesystem is predicted to run out of space within the next 24
+              hours.
+            syn_component: rancher-monitoring
+          expr: "bottomk by (device, host_ip) (1, (\n  node_filesystem_avail_bytes{job=\"\
+            expose-node-metrics\",fstype!=\"\"} / node_filesystem_size_bytes{job=\"\
+            expose-node-metrics\",fstype!=\"\"} * 100 < 40\nand\n  predict_linear(node_filesystem_avail_bytes{job=\"\
+            expose-node-metrics\",fstype!=\"\"}[6h], 24*60*60) < 0\nand\n  node_filesystem_readonly{job=\"\
+            expose-node-metrics\",fstype!=\"\"} == 0\n)\n)"
+          for: 1h
+          labels:
+            severity: warning
+        - alert: NodeFilesystemSpaceFillingUp
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available space left and is
+              filling up fast.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemspacefillingup
+            summary: Filesystem is predicted to run out of space within the next 4
+              hours.
+            syn_component: rancher-monitoring
+          expr: "bottomk by (device, host_ip) (1, (\n  node_filesystem_avail_bytes{job=\"\
+            expose-node-metrics\",fstype!=\"\"} / node_filesystem_size_bytes{job=\"\
+            expose-node-metrics\",fstype!=\"\"} * 100 < 15\nand\n  predict_linear(node_filesystem_avail_bytes{job=\"\
+            expose-node-metrics\",fstype!=\"\"}[6h], 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"\
+            expose-node-metrics\",fstype!=\"\"} == 0\n)\n)"
+          for: 1h
+          labels:
+            severity: critical
+        - alert: NodeFilesystemAlmostOutOfSpace
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available space left.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemalmostoutofspace
+            summary: Filesystem has less than 5% space left.
+            syn_component: rancher-monitoring
+          expr: "bottomk by (device, host_ip) (1, (\n  node_filesystem_avail_bytes{job=\"\
+            expose-node-metrics\",fstype!=\"\"} / node_filesystem_size_bytes{job=\"\
+            expose-node-metrics\",fstype!=\"\"} * 100 < 5\nand\n  node_filesystem_readonly{job=\"\
+            expose-node-metrics\",fstype!=\"\"} == 0\n)\n)"
+          for: 30m
+          labels:
+            severity: warning
+        - alert: NodeFilesystemAlmostOutOfSpace
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available space left.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemalmostoutofspace
+            summary: Filesystem has less than 3% space left.
+            syn_component: rancher-monitoring
+          expr: "bottomk by (device, host_ip) (1, (\n  node_filesystem_avail_bytes{job=\"\
+            expose-node-metrics\",fstype!=\"\"} / node_filesystem_size_bytes{job=\"\
+            expose-node-metrics\",fstype!=\"\"} * 100 < 3\nand\n  node_filesystem_readonly{job=\"\
+            expose-node-metrics\",fstype!=\"\"} == 0\n)\n)"
+          for: 30m
+          labels:
+            severity: critical
+        - alert: NodeFilesystemFilesFillingUp
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available inodes left and is
+              filling up.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemfilesfillingup
+            summary: Filesystem is predicted to run out of inodes within the next
+              24 hours.
+            syn_component: rancher-monitoring
+          expr: "bottomk by (device, host_ip) (1, (\n  node_filesystem_files_free{job=\"\
+            expose-node-metrics\",fstype!=\"\"} / node_filesystem_files{job=\"expose-node-metrics\"\
+            ,fstype!=\"\"} * 100 < 40\nand\n  predict_linear(node_filesystem_files_free{job=\"\
+            expose-node-metrics\",fstype!=\"\"}[6h], 24*60*60) < 0\nand\n  node_filesystem_readonly{job=\"\
+            expose-node-metrics\",fstype!=\"\"} == 0\n)\n)"
+          for: 1h
+          labels:
+            severity: warning
+        - alert: NodeFilesystemFilesFillingUp
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available inodes left and is
+              filling up fast.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemfilesfillingup
+            summary: Filesystem is predicted to run out of inodes within the next
+              4 hours.
+            syn_component: rancher-monitoring
+          expr: "bottomk by (device, host_ip) (1, (\n  node_filesystem_files_free{job=\"\
+            expose-node-metrics\",fstype!=\"\"} / node_filesystem_files{job=\"expose-node-metrics\"\
+            ,fstype!=\"\"} * 100 < 20\nand\n  predict_linear(node_filesystem_files_free{job=\"\
+            expose-node-metrics\",fstype!=\"\"}[6h], 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"\
+            expose-node-metrics\",fstype!=\"\"} == 0\n)\n)"
+          for: 1h
+          labels:
+            severity: critical
+        - alert: NodeFilesystemAlmostOutOfFiles
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available inodes left.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemalmostoutoffiles
+            summary: Filesystem has less than 5% inodes left.
+            syn_component: rancher-monitoring
+          expr: "bottomk by (device, host_ip) (1, (\n  node_filesystem_files_free{job=\"\
+            expose-node-metrics\",fstype!=\"\"} / node_filesystem_files{job=\"expose-node-metrics\"\
+            ,fstype!=\"\"} * 100 < 5\nand\n  node_filesystem_readonly{job=\"expose-node-metrics\"\
+            ,fstype!=\"\"} == 0\n)\n)"
+          for: 1h
+          labels:
+            severity: warning
+        - alert: NodeFilesystemAlmostOutOfFiles
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+              }} has only {{ printf "%.2f" $value }}% available inodes left.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefilesystemalmostoutoffiles
+            summary: Filesystem has less than 3% inodes left.
+            syn_component: rancher-monitoring
+          expr: "bottomk by (device, host_ip) (1, (\n  node_filesystem_files_free{job=\"\
+            expose-node-metrics\",fstype!=\"\"} / node_filesystem_files{job=\"expose-node-metrics\"\
+            ,fstype!=\"\"} * 100 < 3\nand\n  node_filesystem_readonly{job=\"expose-node-metrics\"\
+            ,fstype!=\"\"} == 0\n)\n)"
+          for: 1h
+          labels:
+            severity: critical
+        - alert: NodeNetworkReceiveErrs
+          annotations:
+            description: '{{ $labels.instance }} interface {{ $labels.device }} has
+              encountered {{ printf "%.0f" $value }} receive errors in the last two
+              minutes.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodenetworkreceiveerrs
+            summary: Network interface is reporting many receive errors.
+            syn_component: rancher-monitoring
+          expr: 'rate(node_network_receive_errs_total[2m]) / rate(node_network_receive_packets_total[2m])
+            > 0.01
+
+            '
+          for: 1h
+          labels:
+            severity: warning
+        - alert: NodeNetworkTransmitErrs
+          annotations:
+            description: '{{ $labels.instance }} interface {{ $labels.device }} has
+              encountered {{ printf "%.0f" $value }} transmit errors in the last two
+              minutes.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodenetworktransmiterrs
+            summary: Network interface is reporting many transmit errors.
+            syn_component: rancher-monitoring
+          expr: 'rate(node_network_transmit_errs_total[2m]) / rate(node_network_transmit_packets_total[2m])
+            > 0.01
+
+            '
+          for: 1h
+          labels:
+            severity: warning
+        - alert: NodeHighNumberConntrackEntriesUsed
+          annotations:
+            description: '{{ $value | humanizePercentage }} of conntrack entries are
+              used.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodehighnumberconntrackentriesused
+            summary: Number of conntrack are getting close to the limit.
+            syn_component: rancher-monitoring
+          expr: '(node_nf_conntrack_entries / node_nf_conntrack_entries_limit) > 0.75
+
+            '
+          labels:
+            severity: warning
+        - alert: NodeTextFileCollectorScrapeError
+          annotations:
+            description: Node Exporter text file collector failed to scrape.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodetextfilecollectorscrapeerror
+            summary: Node Exporter text file collector failed to scrape.
+            syn_component: rancher-monitoring
+          expr: 'node_textfile_scrape_error{job="expose-node-metrics"} == 1
+
+            '
+          labels:
+            severity: warning
+        - alert: NodeClockSkewDetected
+          annotations:
+            description: Clock on {{ $labels.instance }} is out of sync by more than
+              300s. Ensure NTP is configured correctly on this host.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodeclockskewdetected
+            summary: Clock skew detected.
+            syn_component: rancher-monitoring
+          expr: "(\n  node_timex_offset_seconds > 0.05\nand\n  deriv(node_timex_offset_seconds[5m])\
+            \ >= 0\n)\nor\n(\n  node_timex_offset_seconds < -0.05\nand\n  deriv(node_timex_offset_seconds[5m])\
+            \ <= 0\n)\n"
+          for: 10m
+          labels:
+            severity: warning
+        - alert: NodeClockNotSynchronising
+          annotations:
+            description: Clock on {{ $labels.instance }} is not synchronising. Ensure
+              NTP is configured on this host.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodeclocknotsynchronising
+            summary: Clock not synchronising.
+            syn_component: rancher-monitoring
+          expr: 'min_over_time(node_timex_sync_status[5m]) == 0
+
+            and
+
+            node_timex_maxerror_seconds >= 16
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+        - alert: NodeRAIDDegraded
+          annotations:
+            description: RAID array '{{ $labels.device }}' on {{ $labels.instance
+              }} is in degraded state due to one or more disks failures. Number of
+              spare drives is insufficient to fix issue automatically.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-noderaiddegraded
+            summary: RAID Array is degraded
+            syn_component: rancher-monitoring
+          expr: 'node_md_disks_required - ignoring (state) (node_md_disks{state="active"})
+            > 0
+
+            '
+          for: 15m
+          labels:
+            severity: critical
+        - alert: NodeRAIDDiskFailure
+          annotations:
+            description: At least one device in RAID array on {{ $labels.instance
+              }} failed. Array '{{ $labels.device }}' needs attention and possibly
+              a disk swap.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-noderaiddiskfailure
+            summary: Failed device in RAID array
+            syn_component: rancher-monitoring
+          expr: 'node_md_disks{state="failed"} > 0
+
+            '
+          labels:
+            severity: warning
+        - alert: NodeFileDescriptorLimit
+          annotations:
+            description: File descriptors limit at {{ $labels.instance }} is currently
+              at {{ printf "%.2f" $value }}%.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefiledescriptorlimit
+            summary: Kernel is predicted to exhaust file descriptors limit soon.
+            syn_component: rancher-monitoring
+          expr: "(\n  node_filefd_allocated{job=\"node-exporter\"} * 100 / node_filefd_maximum{job=\"\
+            node-exporter\"} > 70\n)\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: NodeFileDescriptorLimit
+          annotations:
+            description: File descriptors limit at {{ $labels.instance }} is currently
+              at {{ printf "%.2f" $value }}%.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodefiledescriptorlimit
+            summary: Kernel is predicted to exhaust file descriptors limit soon.
+            syn_component: rancher-monitoring
+          expr: "(\n  node_filefd_allocated{job=\"node-exporter\"} * 100 / node_filefd_maximum{job=\"\
+            node-exporter\"} > 90\n)\n"
+          for: 15m
+          labels:
+            severity: critical
+    - name: node-exporter.rules
+      rules:
+        - expr: "count without (cpu) (\n  count without (mode) (\n    node_cpu_seconds_total{job=\"\
+            expose-node-metrics\"}\n  )\n)\n"
+          record: instance:node_num_cpu:sum
+        - expr: "1 - avg without (cpu, mode) (\n  rate(node_cpu_seconds_total{job=\"\
+            expose-node-metrics\", mode=\"idle\"}[5m])\n)\n"
+          record: instance:node_cpu_utilisation:rate5m
+        - expr: "(\n  node_load1{job=\"expose-node-metrics\"}\n/\n  instance:node_num_cpu:sum{job=\"\
+            expose-node-metrics\"}\n)\n"
+          record: instance:node_load1_per_cpu:ratio
+        - expr: "1 - (\n  node_memory_MemAvailable_bytes{job=\"expose-node-metrics\"\
+            }\n/\n  node_memory_MemTotal_bytes{job=\"expose-node-metrics\"}\n)\n"
+          record: instance:node_memory_utilisation:ratio
+        - expr: 'rate(node_vmstat_pgmajfault{job="expose-node-metrics"}[5m])
+
+            '
+          record: instance:node_vmstat_pgmajfault:rate5m
+        - expr: 'rate(node_disk_io_time_seconds_total{job="expose-node-metrics", device=~"mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"}[5m])
+
+            '
+          record: instance_device:node_disk_io_time_seconds:rate5m
+        - expr: 'rate(node_disk_io_time_weighted_seconds_total{job="expose-node-metrics",
+            device=~"mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"}[5m])
+
+            '
+          record: instance_device:node_disk_io_time_weighted_seconds:rate5m
+        - expr: "sum without (device) (\n  rate(node_network_receive_bytes_total{job=\"\
+            expose-node-metrics\", device!=\"lo\"}[5m])\n)\n"
+          record: instance:node_network_receive_bytes_excluding_lo:rate5m
+        - expr: "sum without (device) (\n  rate(node_network_transmit_bytes_total{job=\"\
+            expose-node-metrics\", device!=\"lo\"}[5m])\n)\n"
+          record: instance:node_network_transmit_bytes_excluding_lo:rate5m
+        - expr: "sum without (device) (\n  rate(node_network_receive_drop_total{job=\"\
+            expose-node-metrics\", device!=\"lo\"}[5m])\n)\n"
+          record: instance:node_network_receive_drop_excluding_lo:rate5m
+        - expr: "sum without (device) (\n  rate(node_network_transmit_drop_total{job=\"\
+            expose-node-metrics\", device!=\"lo\"}[5m])\n)\n"
+          record: instance:node_network_transmit_drop_excluding_lo:rate5m
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.29.1
+    prometheus: platform
+    role: alert-rules
+  name: platform-prometheus-rules
+  namespace: syn-rancher-monitoring
+spec:
+  groups:
+    - name: prometheus
+      rules:
+        - alert: PrometheusBadConfig
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
+              to reload its configuration.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusbadconfig
+            summary: Failed Prometheus configuration reload.
+            syn_component: rancher-monitoring
+          expr: '# Without max_over_time, failed scrapes could create false negatives,
+            see
+
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0
+            for details.
+
+            max_over_time(prometheus_config_last_reload_successful{job="prometheus-k8s",namespace="syn-rancher-monitoring"}[5m])
+            == 0
+
+            '
+          for: 10m
+          labels:
+            severity: critical
+        - alert: PrometheusNotificationQueueRunningFull
+          annotations:
+            description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              is running full.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusnotificationqueuerunningfull
+            summary: Prometheus alert notification queue predicted to run full in
+              less than 30m.
+            syn_component: rancher-monitoring
+          expr: "# Without min_over_time, failed scrapes could create false negatives,\
+            \ see\n# https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0\
+            \ for details.\n(\n  predict_linear(prometheus_notifications_queue_length{job=\"\
+            prometheus-k8s\",namespace=\"syn-rancher-monitoring\"}[5m], 60 * 30)\n\
+            >\n  min_over_time(prometheus_notifications_queue_capacity{job=\"prometheus-k8s\"\
+            ,namespace=\"syn-rancher-monitoring\"}[5m])\n)\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
+          annotations:
+            description: '{{ printf "%.1f" $value }}% errors while sending alerts
+              from Prometheus {{$labels.namespace}}/{{$labels.pod}} to Alertmanager
+              {{$labels.alertmanager}}.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheuserrorsendingalertstosomealertmanagers
+            summary: Prometheus has encountered more than 1% errors sending alerts
+              to a specific Alertmanager.
+            syn_component: rancher-monitoring
+          expr: "(\n  rate(prometheus_notifications_errors_total{job=\"prometheus-k8s\"\
+            ,namespace=\"syn-rancher-monitoring\"}[5m])\n/\n  rate(prometheus_notifications_sent_total{job=\"\
+            prometheus-k8s\",namespace=\"syn-rancher-monitoring\"}[5m])\n)\n* 100\n\
+            > 1\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: PrometheusNotConnectedToAlertmanagers
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
+              to any Alertmanagers.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusnotconnectedtoalertmanagers
+            summary: Prometheus is not connected to any Alertmanagers.
+            syn_component: rancher-monitoring
+          expr: '# Without max_over_time, failed scrapes could create false negatives,
+            see
+
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0
+            for details.
+
+            max_over_time(prometheus_notifications_alertmanagers_discovered{job="prometheus-k8s",namespace="syn-rancher-monitoring"}[5m])
+            < 1
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+        - alert: PrometheusTSDBReloadsFailing
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
+              {{$value | humanize}} reload failures over the last 3h.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheustsdbreloadsfailing
+            summary: Prometheus has issues reloading blocks from disk.
+            syn_component: rancher-monitoring
+          expr: 'increase(prometheus_tsdb_reloads_failures_total{job="prometheus-k8s",namespace="syn-rancher-monitoring"}[3h])
+            > 0
+
+            '
+          for: 4h
+          labels:
+            severity: warning
+        - alert: PrometheusTSDBCompactionsFailing
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
+              {{$value | humanize}} compaction failures over the last 3h.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheustsdbcompactionsfailing
+            summary: Prometheus has issues compacting blocks.
+            syn_component: rancher-monitoring
+          expr: 'increase(prometheus_tsdb_compactions_failed_total{job="prometheus-k8s",namespace="syn-rancher-monitoring"}[3h])
+            > 0
+
+            '
+          for: 4h
+          labels:
+            severity: warning
+        - alert: PrometheusNotIngestingSamples
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
+              samples.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusnotingestingsamples
+            summary: Prometheus is not ingesting samples.
+            syn_component: rancher-monitoring
+          expr: "(\n  rate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus-k8s\"\
+            ,namespace=\"syn-rancher-monitoring\"}[5m]) <= 0\nand\n  (\n    sum without(scrape_job)\
+            \ (prometheus_target_metadata_cache_entries{job=\"prometheus-k8s\",namespace=\"\
+            syn-rancher-monitoring\"}) > 0\n  or\n    sum without(rule_group) (prometheus_rule_group_rules{job=\"\
+            prometheus-k8s\",namespace=\"syn-rancher-monitoring\"}) > 0\n  )\n)\n"
+          for: 10m
+          labels:
+            severity: warning
+        - alert: PrometheusDuplicateTimestamps
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
+              {{ printf "%.4g" $value  }} samples/s with different values but duplicated
+              timestamp.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusduplicatetimestamps
+            summary: Prometheus is dropping samples with duplicate timestamps.
+            syn_component: rancher-monitoring
+          expr: 'rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job="prometheus-k8s",namespace="syn-rancher-monitoring"}[5m])
+            > 0
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+        - alert: PrometheusOutOfOrderTimestamps
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
+              {{ printf "%.4g" $value  }} samples/s with timestamps arriving out of
+              order.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusoutofordertimestamps
+            summary: Prometheus drops samples with out-of-order timestamps.
+            syn_component: rancher-monitoring
+          expr: 'rate(prometheus_target_scrapes_sample_out_of_order_total{job="prometheus-k8s",namespace="syn-rancher-monitoring"}[5m])
+            > 0
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+        - alert: PrometheusRemoteStorageFailures
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to
+              send {{ printf "%.1f" $value }}% of the samples to {{ $labels.remote_name}}:{{
+              $labels.url }}
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusremotestoragefailures
+            summary: Prometheus fails to send samples to remote storage.
+            syn_component: rancher-monitoring
+          expr: "(\n  (rate(prometheus_remote_storage_failed_samples_total{job=\"\
+            prometheus-k8s\",namespace=\"syn-rancher-monitoring\"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job=\"\
+            prometheus-k8s\",namespace=\"syn-rancher-monitoring\"}[5m]))\n/\n  (\n\
+            \    (rate(prometheus_remote_storage_failed_samples_total{job=\"prometheus-k8s\"\
+            ,namespace=\"syn-rancher-monitoring\"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job=\"\
+            prometheus-k8s\",namespace=\"syn-rancher-monitoring\"}[5m]))\n  +\n  \
+            \  (rate(prometheus_remote_storage_succeeded_samples_total{job=\"prometheus-k8s\"\
+            ,namespace=\"syn-rancher-monitoring\"}[5m]) or rate(prometheus_remote_storage_samples_total{job=\"\
+            prometheus-k8s\",namespace=\"syn-rancher-monitoring\"}[5m]))\n  )\n)\n\
+            * 100\n> 1\n"
+          for: 15m
+          labels:
+            severity: critical
+        - alert: PrometheusRemoteWriteBehind
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
+              is {{ printf "%.1f" $value }}s behind for {{ $labels.remote_name}}:{{
+              $labels.url }}.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusremotewritebehind
+            summary: Prometheus remote write is behind.
+            syn_component: rancher-monitoring
+          expr: "# Without max_over_time, failed scrapes could create false negatives,\
+            \ see\n# https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0\
+            \ for details.\n(\n  max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{job=\"\
+            prometheus-k8s\",namespace=\"syn-rancher-monitoring\"}[5m])\n- ignoring(remote_name,\
+            \ url) group_right\n  max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job=\"\
+            prometheus-k8s\",namespace=\"syn-rancher-monitoring\"}[5m])\n)\n> 120\n"
+          for: 15m
+          labels:
+            severity: critical
+        - alert: PrometheusRemoteWriteDesiredShards
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
+              desired shards calculation wants to run {{ $value }} shards for queue
+              {{ $labels.remote_name}}:{{ $labels.url }}, which is more than the max
+              of {{ printf `prometheus_remote_storage_shards_max{instance="%s",job="prometheus-k8s",namespace="syn-rancher-monitoring"}`
+              $labels.instance | query | first | value }}.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusremotewritedesiredshards
+            summary: Prometheus remote write desired shards calculation wants to run
+              more than configured max shards.
+            syn_component: rancher-monitoring
+          expr: "# Without max_over_time, failed scrapes could create false negatives,\
+            \ see\n# https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0\
+            \ for details.\n(\n  max_over_time(prometheus_remote_storage_shards_desired{job=\"\
+            prometheus-k8s\",namespace=\"syn-rancher-monitoring\"}[5m])\n>\n  max_over_time(prometheus_remote_storage_shards_max{job=\"\
+            prometheus-k8s\",namespace=\"syn-rancher-monitoring\"}[5m])\n)\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: PrometheusRuleFailures
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed
+              to evaluate {{ printf "%.0f" $value }} rules in the last 5m.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusrulefailures
+            summary: Prometheus is failing rule evaluations.
+            syn_component: rancher-monitoring
+          expr: 'increase(prometheus_rule_evaluation_failures_total{job="prometheus-k8s",namespace="syn-rancher-monitoring"}[5m])
+            > 0
+
+            '
+          for: 15m
+          labels:
+            severity: critical
+        - alert: PrometheusMissingRuleEvaluations
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed
+              {{ printf "%.0f" $value }} rule group evaluations in the last 5m.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusmissingruleevaluations
+            summary: Prometheus is missing rule evaluations due to slow rule group
+              evaluation.
+            syn_component: rancher-monitoring
+          expr: 'increase(prometheus_rule_group_iterations_missed_total{job="prometheus-k8s",namespace="syn-rancher-monitoring"}[5m])
+            > 0
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: PrometheusTargetLimitHit
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
+              {{ printf "%.0f" $value }} targets because the number of targets exceeded
+              the configured target_limit.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheustargetlimithit
+            summary: Prometheus has dropped targets because some scrape configs have
+              exceeded the targets limit.
+            syn_component: rancher-monitoring
+          expr: 'increase(prometheus_target_scrape_pool_exceeded_target_limit_total{job="prometheus-k8s",namespace="syn-rancher-monitoring"}[5m])
+            > 0
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: PrometheusLabelLimitHit
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped
+              {{ printf "%.0f" $value }} targets because some samples exceeded the
+              configured label_limit, label_name_length_limit or label_value_length_limit.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheuslabellimithit
+            summary: Prometheus has dropped targets because some scrape configs have
+              exceeded the labels limit.
+            syn_component: rancher-monitoring
+          expr: 'increase(prometheus_target_scrape_pool_exceeded_label_limits_total{job="prometheus-k8s",namespace="syn-rancher-monitoring"}[5m])
+            > 0
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: PrometheusTargetSyncFailure
+          annotations:
+            description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              have failed to sync because invalid configuration was supplied.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheustargetsyncfailure
+            summary: Prometheus has failed to sync targets.
+            syn_component: rancher-monitoring
+          expr: 'increase(prometheus_target_sync_failed_total{job="prometheus-k8s",namespace="syn-rancher-monitoring"}[30m])
+            > 0
+
+            '
+          for: 5m
+          labels:
+            severity: critical
+        - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
+          annotations:
+            description: '{{ printf "%.1f" $value }}% minimum errors while sending
+              alerts from Prometheus {{$labels.namespace}}/{{$labels.pod}} to any
+              Alertmanager.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheuserrorsendingalertstoanyalertmanager
+            summary: Prometheus encounters more than 3% errors sending alerts to any
+              Alertmanager.
+            syn_component: rancher-monitoring
+          expr: "min without (alertmanager) (\n  rate(prometheus_notifications_errors_total{job=\"\
+            prometheus-k8s\",namespace=\"syn-rancher-monitoring\",alertmanager!~``}[5m])\n\
+            /\n  rate(prometheus_notifications_sent_total{job=\"prometheus-k8s\",namespace=\"\
+            syn-rancher-monitoring\",alertmanager!~``}[5m])\n)\n* 100\n> 3\n"
+          for: 15m
+          labels:
+            severity: critical
+    - name: node-utilization
+      rules:
+        - alert: node_cpu_load5
+          annotations:
+            message: '{{$labels.instance}}: Load higher than (current value is: {{
+              $value }})'
+          expr: max by(instance) (node_load5) / count by(instance) (node_cpu_seconds_total{mode="idle"})
+            > 2
+          for: 30m
+          labels:
+            severity: critical
+        - alert: node_memory_free_percent
+          annotations:
+            message: '{{$labels.node}}: Memory usage more than 97% (current value
+              is: {{ $value | humanizePercentage }})%'
+          expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes
+            > 0.97
+          for: 30m
+          labels:
+            severity: critical
+    - name: kubernetes-storage-class
+      rules:
+        - alert: KubeStorageClassFillingUp
+          annotations:
+            message: The storage class {{ $labels.storageclass }} is only {{ $value
+              | humanizePercentage }} free.
+            summary: StorageClass is filling up.
+          expr: min by (storageclass)((kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes)
+            < 0.03)*on(persistentvolumeclaim, namespace) group_left(storageclass)
+            kube_persistentvolumeclaim_info{storageclass=""}
+          for: 1m
+          labels:
+            severity: critical
+        - alert: KubeStorageClassFillingUp
+          annotations:
+            message: Based on recent sampling, the storage class {{ $labels.storageclass
+              }} is expected to fill upwithin four days. Currently {{ $value | humanizePercentage
+              }} is available.
+            summary: StorageClass is filling up.
+          expr: min by (storageclass) ((kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes)
+            < 0.15 and predict_linear(kubelet_volume_stats_available_bytes[6h], 4
+            * 24 * 3600) < 0)*on(persistentvolumeclaim, namespace) group_left(storageclass)
+            kube_persistentvolumeclaim_info{storageclass=""}
+          for: 1h
+          labels:
+            severity: warning
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.49.0
+    prometheus: platform
+    role: alert-rules
+  name: platform-prometheus-operator-rules
+  namespace: syn-rancher-monitoring
+spec:
+  groups:
+    - name: prometheus-operator
+      rules:
+        - alert: PrometheusOperatorListErrors
+          annotations:
+            description: Errors while performing List operations in controller {{$labels.controller}}
+              in {{$labels.namespace}} namespace.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusoperatorlisterrors
+            summary: Errors while performing list operations in controller.
+            syn_component: rancher-monitoring
+          expr: '(sum by (controller,namespace) (rate(prometheus_operator_list_operations_failed_total{job="expose-operator-metrics",namespace="cattle-prometheus"}[10m]))
+            / sum by (controller,namespace) (rate(prometheus_operator_list_operations_total{job="expose-operator-metrics",namespace="cattle-prometheus"}[10m])))
+            > 0.4
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: PrometheusOperatorWatchErrors
+          annotations:
+            description: Errors while performing watch operations in controller {{$labels.controller}}
+              in {{$labels.namespace}} namespace.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusoperatorwatcherrors
+            summary: Errors while performing watch operations in controller.
+            syn_component: rancher-monitoring
+          expr: '(sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{job="expose-operator-metrics",namespace="cattle-prometheus"}[10m]))
+            / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{job="expose-operator-metrics",namespace="cattle-prometheus"}[10m])))
+            > 0.4
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: PrometheusOperatorSyncFailed
+          annotations:
+            description: Controller {{ $labels.controller }} in {{ $labels.namespace
+              }} namespace fails to reconcile {{ $value }} objects.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusoperatorsyncfailed
+            summary: Last controller reconciliation failed
+            syn_component: rancher-monitoring
+          expr: 'min_over_time(prometheus_operator_syncs{status="failed",job="expose-operator-metrics",namespace="cattle-prometheus"}[5m])
+            > 0
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+        - alert: PrometheusOperatorReconcileErrors
+          annotations:
+            description: '{{ $value | humanizePercentage }} of reconciling operations
+              failed for {{ $labels.controller }} controller in {{ $labels.namespace
+              }} namespace.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusoperatorreconcileerrors
+            summary: Errors while reconciling controller.
+            syn_component: rancher-monitoring
+          expr: '(sum by (controller,namespace) (rate(prometheus_operator_reconcile_errors_total{job="expose-operator-metrics",namespace="cattle-prometheus"}[5m])))
+            / (sum by (controller,namespace) (rate(prometheus_operator_reconcile_operations_total{job="expose-operator-metrics",namespace="cattle-prometheus"}[5m])))
+            > 0.1
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+        - alert: PrometheusOperatorNodeLookupErrors
+          annotations:
+            description: Errors while reconciling Prometheus in {{ $labels.namespace
+              }} Namespace.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusoperatornodelookuperrors
+            summary: Errors while reconciling Prometheus.
+            syn_component: rancher-monitoring
+          expr: 'rate(prometheus_operator_node_address_lookup_errors_total{job="expose-operator-metrics",namespace="cattle-prometheus"}[5m])
+            > 0.1
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+        - alert: PrometheusOperatorNotReady
+          annotations:
+            description: Prometheus operator in {{ $labels.namespace }} namespace
+              isn't ready to reconcile {{ $labels.controller }} resources.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusoperatornotready
+            summary: Prometheus operator not ready
+            syn_component: rancher-monitoring
+          expr: 'min by(namespace, controller) (max_over_time(prometheus_operator_ready{job="expose-operator-metrics",namespace="cattle-prometheus"}[5m])
+            == 0)
+
+            '
+          for: 5m
+          labels:
+            severity: warning
+        - alert: PrometheusOperatorRejectedResources
+          annotations:
+            description: Prometheus operator in {{ $labels.namespace }} namespace
+              rejected {{ printf "%0.0f" $value }} {{ $labels.controller }}/{{ $labels.resource
+              }} resources.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusoperatorrejectedresources
+            summary: Resources rejected by Prometheus operator
+            syn_component: rancher-monitoring
+          expr: 'min_over_time(prometheus_operator_managed_resources{state="rejected",job="expose-operator-metrics",namespace="cattle-prometheus"}[5m])
+            > 0
+
+            '
+          for: 5m
+          labels:
+            severity: warning
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: platform
+    role: alert-rules
+  name: platform-kubernetes-monitoring-rules
+  namespace: syn-rancher-monitoring
+spec:
+  groups:
+    - name: kubernetes-apps
+      rules:
+        - alert: KubePodCrashLooping
+          annotations:
+            description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
+              }}) is in waiting state (reason: "CrashLoopBackOff").'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping
+            summary: Pod is crash looping.
+            syn_component: rancher-monitoring
+          expr: 'max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff",
+            namespace=~"default|((kube|syn|cattle).*)",job="kube-state-metrics"}[5m])
+            >= 1
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubePodNotReady
+          annotations:
+            description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
+              a non-ready state for longer than 15 minutes.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
+            summary: Pod has been in a non-ready state for more than 15 minutes.
+            syn_component: rancher-monitoring
+          expr: "sum by (namespace, pod) (\n  max by(namespace, pod) (\n    kube_pod_status_phase{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"kube-state-metrics\", phase=~\"\
+            Pending|Unknown\"}\n  ) * on(namespace, pod) group_left(owner_kind) topk\
+            \ by(namespace, pod) (\n    1, max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!=\"\
+            Job\"})\n  )\n) > 0\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeDeploymentGenerationMismatch
+          annotations:
+            description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
+              }} does not match, this indicates that the Deployment has failed but
+              has not been rolled back.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch
+            summary: Deployment generation mismatch due to possible roll-back
+            syn_component: rancher-monitoring
+          expr: "kube_deployment_status_observed_generation{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"kube-state-metrics\"}\n  !=\nkube_deployment_metadata_generation{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"kube-state-metrics\"}\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeDeploymentReplicasMismatch
+          annotations:
+            description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
+              }} has not matched the expected number of replicas for longer than 15
+              minutes.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentreplicasmismatch
+            summary: Deployment has not matched the expected number of replicas.
+            syn_component: rancher-monitoring
+          expr: "(\n  kube_deployment_spec_replicas{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"kube-state-metrics\"}\n    >\n  kube_deployment_status_replicas_available{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"kube-state-metrics\"}\n) and (\n\
+            \  changes(kube_deployment_status_replicas_updated{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"kube-state-metrics\"}[10m])\n    ==\n  0\n)\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeStatefulSetReplicasMismatch
+          annotations:
+            description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
+              }} has not matched the expected number of replicas for longer than 15
+              minutes.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch
+            summary: Deployment has not matched the expected number of replicas.
+            syn_component: rancher-monitoring
+          expr: "(\n  kube_statefulset_status_replicas_ready{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"kube-state-metrics\"}\n    !=\n  kube_statefulset_status_replicas{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"kube-state-metrics\"}\n) and (\n\
+            \  changes(kube_statefulset_status_replicas_updated{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"kube-state-metrics\"}[10m])\n    ==\n  0\n)\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeStatefulSetGenerationMismatch
+          annotations:
+            description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
+              }} does not match, this indicates that the StatefulSet has failed but
+              has not been rolled back.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch
+            summary: StatefulSet generation mismatch due to possible roll-back
+            syn_component: rancher-monitoring
+          expr: "kube_statefulset_status_observed_generation{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"kube-state-metrics\"}\n  !=\nkube_statefulset_metadata_generation{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"kube-state-metrics\"}\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeStatefulSetUpdateNotRolledOut
+          annotations:
+            description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
+              }} update has not been rolled out.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout
+            summary: StatefulSet update has not been rolled out.
+            syn_component: rancher-monitoring
+          expr: "(\n  max without (revision) (\n    kube_statefulset_status_current_revision{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"kube-state-metrics\"}\n      unless\n\
+            \    kube_statefulset_status_update_revision{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"kube-state-metrics\"}\n  )\n    *\n  (\n    kube_statefulset_replicas{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"kube-state-metrics\"}\n      !=\n\
+            \    kube_statefulset_status_replicas_updated{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"kube-state-metrics\"}\n  )\n)  and (\n  changes(kube_statefulset_status_replicas_updated{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"kube-state-metrics\"}[5m])\n   \
+            \ ==\n  0\n)\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeDaemonSetRolloutStuck
+          annotations:
+            description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
+              has not finished or progressed for at least 15 minutes.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck
+            summary: DaemonSet rollout is stuck.
+            syn_component: rancher-monitoring
+          expr: "(\n  (\n    kube_daemonset_status_current_number_scheduled{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"kube-state-metrics\"}\n     !=\n\
+            \    kube_daemonset_status_desired_number_scheduled{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"kube-state-metrics\"}\n  ) or (\n    kube_daemonset_status_number_misscheduled{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"kube-state-metrics\"}\n     !=\n\
+            \    0\n  ) or (\n    kube_daemonset_updated_number_scheduled{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"kube-state-metrics\"}\n     !=\n\
+            \    kube_daemonset_status_desired_number_scheduled{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"kube-state-metrics\"}\n  ) or (\n    kube_daemonset_status_number_available{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"kube-state-metrics\"}\n     !=\n\
+            \    kube_daemonset_status_desired_number_scheduled{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"kube-state-metrics\"}\n  )\n) and (\n  changes(kube_daemonset_updated_number_scheduled{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"kube-state-metrics\"}[5m])\n   \
+            \ ==\n  0\n)\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeContainerWaiting
+          annotations:
+            description: Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{
+              $labels.container}} has been in waiting state for longer than 1 hour.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontainerwaiting
+            summary: Pod container waiting longer than 1 hour
+            syn_component: rancher-monitoring
+          expr: 'sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{namespace=~"default|((kube|syn|cattle).*)",job="kube-state-metrics"})
+            > 0
+
+            '
+          for: 1h
+          labels:
+            severity: warning
+        - alert: KubeDaemonSetNotScheduled
+          annotations:
+            description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
+              $labels.daemonset }} are not scheduled.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled
+            summary: DaemonSet pods are not scheduled.
+            syn_component: rancher-monitoring
+          expr: "kube_daemonset_status_desired_number_scheduled{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"kube-state-metrics\"}\n  -\nkube_daemonset_status_current_number_scheduled{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"kube-state-metrics\"} > 0\n"
+          for: 10m
+          labels:
+            severity: warning
+        - alert: KubeDaemonSetMisScheduled
+          annotations:
+            description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
+              $labels.daemonset }} are running where they are not supposed to run.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled
+            summary: DaemonSet pods are misscheduled.
+            syn_component: rancher-monitoring
+          expr: 'kube_daemonset_status_number_misscheduled{namespace=~"default|((kube|syn|cattle).*)",job="kube-state-metrics"}
+            > 0
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeJobCompletion
+          annotations:
+            description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
+              more than 12 hours to complete.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
+            summary: Job did not complete in time
+            syn_component: rancher-monitoring
+          expr: 'kube_job_spec_completions{namespace=~"default|((kube|syn|cattle).*)",job="kube-state-metrics"}
+            - kube_job_status_succeeded{namespace=~"default|((kube|syn|cattle).*)",job="kube-state-metrics"}  >
+            0
+
+            '
+          for: 12h
+          labels:
+            severity: warning
+        - alert: KubeJobFailed
+          annotations:
+            description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
+              to complete. Removing failed job after investigation should clear this
+              alert.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
+            summary: Job failed to complete.
+            syn_component: rancher-monitoring
+          expr: 'kube_job_failed{namespace=~"default|((kube|syn|cattle).*)",job="kube-state-metrics"}  >
+            0
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+    - name: kubernetes-resources
+      rules:
+        - alert: KubeCPUOvercommit
+          annotations:
+            description: Cluster has overcommitted CPU resource requests for Pods
+              by {{ $value }} CPU shares and cannot tolerate node failure.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit
+            summary: Cluster has overcommitted CPU resource requests.
+            syn_component: rancher-monitoring
+          expr: 'sum(namespace_cpu:kube_pod_container_resource_requests:sum{}) - (sum(kube_node_status_allocatable{resource="cpu"})
+            - max(kube_node_status_allocatable{resource="cpu"})) > 0
+
+            and
+
+            (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"}))
+            > 0
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+        - alert: KubeMemoryOvercommit
+          annotations:
+            description: Cluster has overcommitted memory resource requests for Pods
+              by {{ $value }} bytes and cannot tolerate node failure.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryovercommit
+            summary: Cluster has overcommitted memory resource requests.
+            syn_component: rancher-monitoring
+          expr: 'sum(namespace_memory:kube_pod_container_resource_requests:sum{})
+            - (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"}))
+            > 0
+
+            and
+
+            (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"}))
+            > 0
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+        - alert: KubeCPUQuotaOvercommit
+          annotations:
+            description: Cluster has overcommitted CPU resource requests for Namespaces.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit
+            summary: Cluster has overcommitted CPU resource requests.
+            syn_component: rancher-monitoring
+          expr: "sum(kube_resourcequota{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"kube-state-metrics\", type=\"hard\", resource=\"cpu\"})\n  /\n\
+            sum(kube_node_status_allocatable{resource=\"cpu\"})\n  > 1.5\n"
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KubeMemoryQuotaOvercommit
+          annotations:
+            description: Cluster has overcommitted memory resource requests for Namespaces.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit
+            summary: Cluster has overcommitted memory resource requests.
+            syn_component: rancher-monitoring
+          expr: "sum(kube_resourcequota{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"kube-state-metrics\", type=\"hard\", resource=\"memory\"})\n  /\n\
+            sum(kube_node_status_allocatable{resource=\"memory\",job=\"kube-state-metrics\"\
+            })\n  > 1.5\n"
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KubeQuotaAlmostFull
+          annotations:
+            description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
+              }} of its {{ $labels.resource }} quota.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaalmostfull
+            summary: Namespace quota is going to be full.
+            syn_component: rancher-monitoring
+          expr: "kube_resourcequota{namespace=~\"default|((kube|syn|cattle).*)\",job=\"\
+            kube-state-metrics\", type=\"used\"}\n  / ignoring(instance, job, type)\n\
+            (kube_resourcequota{namespace=~\"default|((kube|syn|cattle).*)\",job=\"\
+            kube-state-metrics\", type=\"hard\"} > 0)\n  > 0.9 < 1\n"
+          for: 15m
+          labels:
+            severity: info
+        - alert: KubeQuotaFullyUsed
+          annotations:
+            description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
+              }} of its {{ $labels.resource }} quota.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotafullyused
+            summary: Namespace quota is fully used.
+            syn_component: rancher-monitoring
+          expr: "kube_resourcequota{namespace=~\"default|((kube|syn|cattle).*)\",job=\"\
+            kube-state-metrics\", type=\"used\"}\n  / ignoring(instance, job, type)\n\
+            (kube_resourcequota{namespace=~\"default|((kube|syn|cattle).*)\",job=\"\
+            kube-state-metrics\", type=\"hard\"} > 0)\n  == 1\n"
+          for: 15m
+          labels:
+            severity: info
+        - alert: KubeQuotaExceeded
+          annotations:
+            description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
+              }} of its {{ $labels.resource }} quota.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded
+            summary: Namespace quota has exceeded the limits.
+            syn_component: rancher-monitoring
+          expr: "kube_resourcequota{namespace=~\"default|((kube|syn|cattle).*)\",job=\"\
+            kube-state-metrics\", type=\"used\"}\n  / ignoring(instance, job, type)\n\
+            (kube_resourcequota{namespace=~\"default|((kube|syn|cattle).*)\",job=\"\
+            kube-state-metrics\", type=\"hard\"} > 0)\n  > 1\n"
+          for: 15m
+          labels:
+            severity: warning
+    - name: kubernetes-storage
+      rules:
+        - alert: KubePersistentVolumeFillingUp
+          annotations:
+            description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
+              }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage
+              }} free.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup
+            summary: PersistentVolume is filling up.
+            syn_component: rancher-monitoring
+          expr: "min by (persistentvolumeclaim, namespace) ((\n  kubelet_volume_stats_available_bytes{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"expose-kubelets-metrics\"}\n   \
+            \ /\n  kubelet_volume_stats_capacity_bytes{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"expose-kubelets-metrics\"}\n) < 0.03\nand\nkubelet_volume_stats_used_bytes{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"expose-kubelets-metrics\"} > 0\n\
+            )*on(persistentvolumeclaim, namespace) group_left(storageclass) kube_persistentvolumeclaim_info{storageclass!~\"\
+            \"}"
+          for: 1m
+          labels:
+            severity: critical
+        - alert: KubePersistentVolumeFillingUp
+          annotations:
+            description: Based on recent sampling, the PersistentVolume claimed by
+              {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace
+              }} is expected to fill up within four days. Currently {{ $value | humanizePercentage
+              }} is available.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup
+            summary: PersistentVolume is filling up.
+            syn_component: rancher-monitoring
+          expr: "min by (persistentvolumeclaim, namespace) ((\n  kubelet_volume_stats_available_bytes{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"expose-kubelets-metrics\"}\n   \
+            \ /\n  kubelet_volume_stats_capacity_bytes{namespace=~\"default|((kube|syn|cattle).*)\"\
+            ,job=\"expose-kubelets-metrics\"}\n) < 0.15\nand\nkubelet_volume_stats_used_bytes{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"expose-kubelets-metrics\"} > 0\n\
+            and\npredict_linear(kubelet_volume_stats_available_bytes{namespace=~\"\
+            default|((kube|syn|cattle).*)\",job=\"expose-kubelets-metrics\"}[6h],\
+            \ 4 * 24 * 3600) < 0\n)*on(persistentvolumeclaim, namespace) group_left(storageclass)\
+            \ kube_persistentvolumeclaim_info{storageclass!~\"\"}"
+          for: 1h
+          labels:
+            severity: warning
+        - alert: KubePersistentVolumeErrors
+          annotations:
+            description: The persistent volume {{ $labels.persistentvolume }} has
+              status {{ $labels.phase }}.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors
+            summary: PersistentVolume is having issues with provisioning.
+            syn_component: rancher-monitoring
+          expr: 'kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"default|((kube|syn|cattle).*)",job="kube-state-metrics"}
+            > 0
+
+            '
+          for: 5m
+          labels:
+            severity: critical
+    - name: kubernetes-system
+      rules:
+        - alert: KubeVersionMismatch
+          annotations:
+            description: There are {{ $value }} different semantic versions of Kubernetes
+              components running.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeversionmismatch
+            summary: Different semantic versions of Kubernetes components running.
+            syn_component: rancher-monitoring
+          expr: 'count(count by (git_version) (label_replace(kubernetes_build_info{job!~"kube-dns|coredns"},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*")))
+            > 1
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeClientErrors
+          annotations:
+            description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
+              }}' is experiencing {{ $value | humanizePercentage }} errors.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclienterrors
+            summary: Kubernetes API server client is experiencing errors.
+            syn_component: rancher-monitoring
+          expr: "(sum(rate(rest_client_requests_total{code=~\"5..\"}[5m])) by (instance,\
+            \ job, namespace)\n  /\nsum(rate(rest_client_requests_total[5m])) by (instance,\
+            \ job, namespace))\n> 0.01\n"
+          for: 15m
+          labels:
+            severity: warning
+    - name: kube-apiserver-slos
+      rules:
+        - alert: KubeAPIErrorBudgetBurn
+          annotations:
+            description: The API server is burning too much error budget.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn
+            summary: The API server is burning too much error budget.
+            syn_component: rancher-monitoring
+          expr: 'sum(apiserver_request:burnrate1h) > (14.40 * 0.01000)
+
+            and
+
+            sum(apiserver_request:burnrate5m) > (14.40 * 0.01000)
+
+            '
+          for: 2m
+          labels:
+            long: 1h
+            severity: critical
+            short: 5m
+        - alert: KubeAPIErrorBudgetBurn
+          annotations:
+            description: The API server is burning too much error budget.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn
+            summary: The API server is burning too much error budget.
+            syn_component: rancher-monitoring
+          expr: 'sum(apiserver_request:burnrate6h) > (6.00 * 0.01000)
+
+            and
+
+            sum(apiserver_request:burnrate30m) > (6.00 * 0.01000)
+
+            '
+          for: 15m
+          labels:
+            long: 6h
+            severity: critical
+            short: 30m
+        - alert: KubeAPIErrorBudgetBurn
+          annotations:
+            description: The API server is burning too much error budget.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn
+            summary: The API server is burning too much error budget.
+            syn_component: rancher-monitoring
+          expr: 'sum(apiserver_request:burnrate1d) > (3.00 * 0.01000)
+
+            and
+
+            sum(apiserver_request:burnrate2h) > (3.00 * 0.01000)
+
+            '
+          for: 1h
+          labels:
+            long: 1d
+            severity: warning
+            short: 2h
+        - alert: KubeAPIErrorBudgetBurn
+          annotations:
+            description: The API server is burning too much error budget.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn
+            summary: The API server is burning too much error budget.
+            syn_component: rancher-monitoring
+          expr: 'sum(apiserver_request:burnrate3d) > (1.00 * 0.01000)
+
+            and
+
+            sum(apiserver_request:burnrate6h) > (1.00 * 0.01000)
+
+            '
+          for: 3h
+          labels:
+            long: 3d
+            severity: warning
+            short: 6h
+    - name: kubernetes-system-apiserver
+      rules:
+        - alert: KubeClientCertificateExpiration
+          annotations:
+            description: A client certificate used to authenticate to the apiserver
+              is expiring in less than 7.0 days.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclientcertificateexpiration
+            summary: Client certificate is about to expire.
+            syn_component: rancher-monitoring
+          expr: 'apiserver_client_certificate_expiration_seconds_count{job="kubernetes"}
+            > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="kubernetes"}[5m])))
+            < 604800
+
+            '
+          labels:
+            severity: warning
+        - alert: KubeClientCertificateExpiration
+          annotations:
+            description: A client certificate used to authenticate to the apiserver
+              is expiring in less than 24.0 hours.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclientcertificateexpiration
+            summary: Client certificate is about to expire.
+            syn_component: rancher-monitoring
+          expr: 'apiserver_client_certificate_expiration_seconds_count{job="kubernetes"}
+            > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="kubernetes"}[5m])))
+            < 86400
+
+            '
+          labels:
+            severity: critical
+        - alert: AggregatedAPIErrors
+          annotations:
+            description: An aggregated API {{ $labels.name }}/{{ $labels.namespace
+              }} has reported errors. It has appeared unavailable {{ $value | humanize
+              }} times averaged over the past 10m.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-aggregatedapierrors
+            summary: An aggregated API has reported errors.
+            syn_component: rancher-monitoring
+          expr: 'sum by(name, namespace)(increase(aggregator_unavailable_apiservice_total[10m]))
+            > 4
+
+            '
+          labels:
+            severity: warning
+        - alert: KubeAPIDown
+          annotations:
+            description: KubeAPI has disappeared from Prometheus target discovery.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapidown
+            summary: Target disappeared from Prometheus target discovery.
+            syn_component: rancher-monitoring
+          expr: 'absent(up{job="kubernetes"} == 1)
+
+            '
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeAPITerminatedRequests
+          annotations:
+            description: The apiserver has terminated {{ $value | humanizePercentage
+              }} of its incoming requests.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapiterminatedrequests
+            summary: The apiserver has terminated {{ $value | humanizePercentage }}
+              of its incoming requests.
+            syn_component: rancher-monitoring
+          expr: 'sum(rate(apiserver_request_terminations_total{job="kubernetes"}[10m]))  /
+            (  sum(rate(apiserver_request_total{job="kubernetes"}[10m])) + sum(rate(apiserver_request_terminations_total{job="kubernetes"}[10m]))
+            ) > 0.20
+
+            '
+          for: 5m
+          labels:
+            severity: warning
+    - name: kubernetes-system-kubelet
+      rules:
+        - alert: KubeNodeNotReady
+          annotations:
+            description: '{{ $labels.node }} has been unready for more than 15 minutes.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodenotready
+            summary: Node is not ready.
+            syn_component: rancher-monitoring
+          expr: 'kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"}
+            == 0
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeNodeUnreachable
+          annotations:
+            description: '{{ $labels.node }} is unreachable and some workloads may
+              be rescheduled.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodeunreachable
+            summary: Node is unreachable.
+            syn_component: rancher-monitoring
+          expr: '(kube_node_spec_taint{job="kube-state-metrics",key="node.kubernetes.io/unreachable",effect="NoSchedule"}
+            unless ignoring(key,value) kube_node_spec_taint{job="kube-state-metrics",key=~"ToBeDeletedByClusterAutoscaler|cloud.google.com/impending-node-termination|aws-node-termination-handler/spot-itn"})
+            == 1
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeletTooManyPods
+          annotations:
+            description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
+              }} of its Pod capacity.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods
+            summary: Kubelet is running at capacity.
+            syn_component: rancher-monitoring
+          expr: "count by(node) (\n  (kube_pod_status_phase{job=\"kube-state-metrics\"\
+            ,phase=\"Running\"} == 1) * on(instance,pod,namespace,cluster) group_left(node)\
+            \ topk by(instance,pod,namespace,cluster) (1, kube_pod_info{job=\"kube-state-metrics\"\
+            })\n)\n/\nmax by(node) (\n  kube_node_status_capacity{job=\"kube-state-metrics\"\
+            ,resource=\"pods\"} != 1\n) > 0.95\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeNodeReadinessFlapping
+          annotations:
+            description: The readiness status of node {{ $labels.node }} has changed
+              {{ $value }} times in the last 15 minutes.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodereadinessflapping
+            summary: Node readiness status is flapping.
+            syn_component: rancher-monitoring
+          expr: 'sum(changes(kube_node_status_condition{status="true",condition="Ready"}[15m]))
+            by (node) > 2
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeletPlegDurationHigh
+          annotations:
+            description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
+              duration of {{ $value }} seconds on node {{ $labels.node }}.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletplegdurationhigh
+            summary: Kubelet Pod Lifecycle Event Generator is taking too long to relist.
+            syn_component: rancher-monitoring
+          expr: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile{quantile="0.99"}
+            >= 10
+
+            '
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KubeletPodStartUpLatencyHigh
+          annotations:
+            description: Kubelet Pod startup 99th percentile latency is {{ $value
+              }} seconds on node {{ $labels.node }}.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletpodstartuplatencyhigh
+            summary: Kubelet Pod startup latency is too high.
+            syn_component: rancher-monitoring
+          expr: 'histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{job="expose-kubelets-metrics"}[5m]))
+            by (instance, le)) * on(instance) group_left(node) kubelet_node_name{job="expose-kubelets-metrics"}
+            > 60
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeletClientCertificateExpiration
+          annotations:
+            description: Client certificate for Kubelet on node {{ $labels.node }}
+              expires in {{ $value | humanizeDuration }}.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration
+            summary: Kubelet client certificate is about to expire.
+            syn_component: rancher-monitoring
+          expr: 'kubelet_certificate_manager_client_ttl_seconds < 604800
+
+            '
+          labels:
+            severity: warning
+        - alert: KubeletClientCertificateExpiration
+          annotations:
+            description: Client certificate for Kubelet on node {{ $labels.node }}
+              expires in {{ $value | humanizeDuration }}.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration
+            summary: Kubelet client certificate is about to expire.
+            syn_component: rancher-monitoring
+          expr: 'kubelet_certificate_manager_client_ttl_seconds < 86400
+
+            '
+          labels:
+            severity: critical
+        - alert: KubeletServerCertificateExpiration
+          annotations:
+            description: Server certificate for Kubelet on node {{ $labels.node }}
+              expires in {{ $value | humanizeDuration }}.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration
+            summary: Kubelet server certificate is about to expire.
+            syn_component: rancher-monitoring
+          expr: 'kubelet_certificate_manager_server_ttl_seconds < 604800
+
+            '
+          labels:
+            severity: warning
+        - alert: KubeletServerCertificateExpiration
+          annotations:
+            description: Server certificate for Kubelet on node {{ $labels.node }}
+              expires in {{ $value | humanizeDuration }}.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration
+            summary: Kubelet server certificate is about to expire.
+            syn_component: rancher-monitoring
+          expr: 'kubelet_certificate_manager_server_ttl_seconds < 86400
+
+            '
+          labels:
+            severity: critical
+        - alert: KubeletClientCertificateRenewalErrors
+          annotations:
+            description: Kubelet on node {{ $labels.node }} has failed to renew its
+              client certificate ({{ $value | humanize }} errors in the last 5 minutes).
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificaterenewalerrors
+            summary: Kubelet has failed to renew its client certificate.
+            syn_component: rancher-monitoring
+          expr: 'increase(kubelet_certificate_manager_client_expiration_renew_errors[5m])
+            > 0
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeletServerCertificateRenewalErrors
+          annotations:
+            description: Kubelet on node {{ $labels.node }} has failed to renew its
+              server certificate ({{ $value | humanize }} errors in the last 5 minutes).
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificaterenewalerrors
+            summary: Kubelet has failed to renew its server certificate.
+            syn_component: rancher-monitoring
+          expr: 'increase(kubelet_server_expiration_renew_errors[5m]) > 0
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeletDown
+          annotations:
+            description: Kubelet has disappeared from Prometheus target discovery.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletdown
+            summary: Target disappeared from Prometheus target discovery.
+            syn_component: rancher-monitoring
+          expr: 'absent(up{job="expose-kubelets-metrics"} == 1)
+
+            '
+          for: 15m
+          labels:
+            severity: critical
+    - name: kube-apiserver-burnrate.rules
+      rules:
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"LIST|GET\"}[1d]))\n    -\n    (\n      (\n      \
+            \  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[1d]))\n\
+            \        or\n        vector(0)\n      )\n      +\n      sum by (cluster)\
+            \ (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\",verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[1d]))\n      +\n      sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\"\
+            ,verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[1d]))\n    )\n  )\n \
+            \ +\n  # errors\n  sum by (cluster) (rate(apiserver_request_total{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",code=~\"5..\"}[1d]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"LIST|GET\"\
+            }[1d]))\n"
+          labels:
+            verb: read
+          record: apiserver_request:burnrate1d
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"LIST|GET\"}[1h]))\n    -\n    (\n      (\n      \
+            \  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[1h]))\n\
+            \        or\n        vector(0)\n      )\n      +\n      sum by (cluster)\
+            \ (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\",verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[1h]))\n      +\n      sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\"\
+            ,verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[1h]))\n    )\n  )\n \
+            \ +\n  # errors\n  sum by (cluster) (rate(apiserver_request_total{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",code=~\"5..\"}[1h]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"LIST|GET\"\
+            }[1h]))\n"
+          labels:
+            verb: read
+          record: apiserver_request:burnrate1h
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"LIST|GET\"}[2h]))\n    -\n    (\n      (\n      \
+            \  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[2h]))\n\
+            \        or\n        vector(0)\n      )\n      +\n      sum by (cluster)\
+            \ (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\",verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[2h]))\n      +\n      sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\"\
+            ,verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[2h]))\n    )\n  )\n \
+            \ +\n  # errors\n  sum by (cluster) (rate(apiserver_request_total{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",code=~\"5..\"}[2h]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"LIST|GET\"\
+            }[2h]))\n"
+          labels:
+            verb: read
+          record: apiserver_request:burnrate2h
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"LIST|GET\"}[30m]))\n    -\n    (\n      (\n     \
+            \   sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[30m]))\n\
+            \        or\n        vector(0)\n      )\n      +\n      sum by (cluster)\
+            \ (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\",verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[30m]))\n      +\n      sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\"\
+            ,verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[30m]))\n    )\n  )\n\
+            \  +\n  # errors\n  sum by (cluster) (rate(apiserver_request_total{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",code=~\"5..\"}[30m]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"LIST|GET\"\
+            }[30m]))\n"
+          labels:
+            verb: read
+          record: apiserver_request:burnrate30m
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"LIST|GET\"}[3d]))\n    -\n    (\n      (\n      \
+            \  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[3d]))\n\
+            \        or\n        vector(0)\n      )\n      +\n      sum by (cluster)\
+            \ (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\",verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[3d]))\n      +\n      sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\"\
+            ,verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[3d]))\n    )\n  )\n \
+            \ +\n  # errors\n  sum by (cluster) (rate(apiserver_request_total{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",code=~\"5..\"}[3d]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"LIST|GET\"\
+            }[3d]))\n"
+          labels:
+            verb: read
+          record: apiserver_request:burnrate3d
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"LIST|GET\"}[5m]))\n    -\n    (\n      (\n      \
+            \  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[5m]))\n\
+            \        or\n        vector(0)\n      )\n      +\n      sum by (cluster)\
+            \ (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\",verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[5m]))\n      +\n      sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\"\
+            ,verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[5m]))\n    )\n  )\n \
+            \ +\n  # errors\n  sum by (cluster) (rate(apiserver_request_total{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",code=~\"5..\"}[5m]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"LIST|GET\"\
+            }[5m]))\n"
+          labels:
+            verb: read
+          record: apiserver_request:burnrate5m
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"LIST|GET\"}[6h]))\n    -\n    (\n      (\n      \
+            \  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[6h]))\n\
+            \        or\n        vector(0)\n      )\n      +\n      sum by (cluster)\
+            \ (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\",verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[6h]))\n      +\n      sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\"\
+            ,verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[6h]))\n    )\n  )\n \
+            \ +\n  # errors\n  sum by (cluster) (rate(apiserver_request_total{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",code=~\"5..\"}[6h]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"LIST|GET\"\
+            }[6h]))\n"
+          labels:
+            verb: read
+          record: apiserver_request:burnrate6h
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"}[1d]))\n    -\n    sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\"\
+            ,verb=~\"POST|PUT|PATCH|DELETE\",le=\"1\"}[1d]))\n  )\n  +\n  sum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"\
+            ,code=~\"5..\"}[1d]))\n)\n/\nsum by (cluster) (rate(apiserver_request_total{job=\"\
+            kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"}[1d]))\n"
+          labels:
+            verb: write
+          record: apiserver_request:burnrate1d
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"}[1h]))\n    -\n    sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\"\
+            ,verb=~\"POST|PUT|PATCH|DELETE\",le=\"1\"}[1h]))\n  )\n  +\n  sum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"\
+            ,code=~\"5..\"}[1h]))\n)\n/\nsum by (cluster) (rate(apiserver_request_total{job=\"\
+            kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"}[1h]))\n"
+          labels:
+            verb: write
+          record: apiserver_request:burnrate1h
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"}[2h]))\n    -\n    sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\"\
+            ,verb=~\"POST|PUT|PATCH|DELETE\",le=\"1\"}[2h]))\n  )\n  +\n  sum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"\
+            ,code=~\"5..\"}[2h]))\n)\n/\nsum by (cluster) (rate(apiserver_request_total{job=\"\
+            kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"}[2h]))\n"
+          labels:
+            verb: write
+          record: apiserver_request:burnrate2h
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"}[30m]))\n    -\n    sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\"\
+            ,verb=~\"POST|PUT|PATCH|DELETE\",le=\"1\"}[30m]))\n  )\n  +\n  sum by\
+            \ (cluster) (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"\
+            POST|PUT|PATCH|DELETE\",code=~\"5..\"}[30m]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"\
+            }[30m]))\n"
+          labels:
+            verb: write
+          record: apiserver_request:burnrate30m
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"}[3d]))\n    -\n    sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\"\
+            ,verb=~\"POST|PUT|PATCH|DELETE\",le=\"1\"}[3d]))\n  )\n  +\n  sum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"\
+            ,code=~\"5..\"}[3d]))\n)\n/\nsum by (cluster) (rate(apiserver_request_total{job=\"\
+            kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"}[3d]))\n"
+          labels:
+            verb: write
+          record: apiserver_request:burnrate3d
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"}[5m]))\n    -\n    sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\"\
+            ,verb=~\"POST|PUT|PATCH|DELETE\",le=\"1\"}[5m]))\n  )\n  +\n  sum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"\
+            ,code=~\"5..\"}[5m]))\n)\n/\nsum by (cluster) (rate(apiserver_request_total{job=\"\
+            kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"}[5m]))\n"
+          labels:
+            verb: write
+          record: apiserver_request:burnrate5m
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"}[6h]))\n    -\n    sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"kubernetes\"\
+            ,verb=~\"POST|PUT|PATCH|DELETE\",le=\"1\"}[6h]))\n  )\n  +\n  sum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"\
+            ,code=~\"5..\"}[6h]))\n)\n/\nsum by (cluster) (rate(apiserver_request_total{job=\"\
+            kubernetes\",verb=~\"POST|PUT|PATCH|DELETE\"}[6h]))\n"
+          labels:
+            verb: write
+          record: apiserver_request:burnrate6h
+    - name: kube-apiserver-histogram.rules
+      rules:
+        - expr: 'histogram_quantile(0.99, sum by (cluster, le, resource) (rate(apiserver_request_duration_seconds_bucket{job="kubernetes",verb=~"LIST|GET"}[5m])))
+            > 0
+
+            '
+          labels:
+            quantile: '0.99'
+            verb: read
+          record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.99, sum by (cluster, le, resource) (rate(apiserver_request_duration_seconds_bucket{job="kubernetes",verb=~"POST|PUT|PATCH|DELETE"}[5m])))
+            > 0
+
+            '
+          labels:
+            quantile: '0.99'
+            verb: write
+          record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.99'
+          record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.9'
+          record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket{job="kubernetes",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.5'
+          record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+    - interval: 3m
+      name: kube-apiserver-availability.rules
+      rules:
+        - expr: 'avg_over_time(code_verb:apiserver_request_total:increase1h[30d])
+            * 24 * 30
+
+            '
+          record: code_verb:apiserver_request_total:increase30d
+        - expr: 'sum by (cluster, code) (code_verb:apiserver_request_total:increase30d{verb=~"LIST|GET"})
+
+            '
+          labels:
+            verb: read
+          record: code:apiserver_request_total:increase30d
+        - expr: 'sum by (cluster, code) (code_verb:apiserver_request_total:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
+
+            '
+          labels:
+            verb: write
+          record: code:apiserver_request_total:increase30d
+        - expr: "1 - (\n  (\n    # write too slow\n    sum by (cluster) (increase(apiserver_request_duration_seconds_count{verb=~\"\
+            POST|PUT|PATCH|DELETE\"}[30d]))\n    -\n    sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~\"\
+            POST|PUT|PATCH|DELETE\",le=\"1\"}[30d]))\n  ) +\n  (\n    # read too slow\n\
+            \    sum by (cluster) (increase(apiserver_request_duration_seconds_count{verb=~\"\
+            LIST|GET\"}[30d]))\n    -\n    (\n      (\n        sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~\"\
+            LIST|GET\",scope=~\"resource|\",le=\"1\"}[30d]))\n        or\n       \
+            \ vector(0)\n      )\n      +\n      sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[30d]))\n      +\n      sum by\
+            \ (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~\"\
+            LIST|GET\",scope=\"cluster\",le=\"40\"}[30d]))\n    )\n  ) +\n  # errors\n\
+            \  sum by (cluster) (code:apiserver_request_total:increase30d{code=~\"\
+            5..\"} or vector(0))\n)\n/\nsum by (cluster) (code:apiserver_request_total:increase30d)\n"
+          labels:
+            verb: all
+          record: apiserver_request:availability30d
+        - expr: "1 - (\n  sum by (cluster) (increase(apiserver_request_duration_seconds_count{job=\"\
+            kubernetes\",verb=~\"LIST|GET\"}[30d]))\n  -\n  (\n    # too slow\n  \
+            \  (\n      sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[30d]))\n\
+            \      or\n      vector(0)\n    )\n    +\n    sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",scope=\"namespace\",le=\"5\"}[30d]))\n\
+            \    +\n    sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{job=\"\
+            kubernetes\",verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[30d]))\n\
+            \  )\n  +\n  # errors\n  sum by (cluster) (code:apiserver_request_total:increase30d{verb=\"\
+            read\",code=~\"5..\"} or vector(0))\n)\n/\nsum by (cluster) (code:apiserver_request_total:increase30d{verb=\"\
+            read\"})\n"
+          labels:
+            verb: read
+          record: apiserver_request:availability30d
+        - expr: "1 - (\n  (\n    # too slow\n    sum by (cluster) (increase(apiserver_request_duration_seconds_count{verb=~\"\
+            POST|PUT|PATCH|DELETE\"}[30d]))\n    -\n    sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~\"\
+            POST|PUT|PATCH|DELETE\",le=\"1\"}[30d]))\n  )\n  +\n  # errors\n  sum\
+            \ by (cluster) (code:apiserver_request_total:increase30d{verb=\"write\"\
+            ,code=~\"5..\"} or vector(0))\n)\n/\nsum by (cluster) (code:apiserver_request_total:increase30d{verb=\"\
+            write\"})\n"
+          labels:
+            verb: write
+          record: apiserver_request:availability30d
+        - expr: 'sum by (cluster,code,resource) (rate(apiserver_request_total{job="kubernetes",verb=~"LIST|GET"}[5m]))
+
+            '
+          labels:
+            verb: read
+          record: code_resource:apiserver_request_total:rate5m
+        - expr: 'sum by (cluster,code,resource) (rate(apiserver_request_total{job="kubernetes",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+
+            '
+          labels:
+            verb: write
+          record: code_resource:apiserver_request_total:rate5m
+        - expr: 'sum by (cluster, code, verb) (increase(apiserver_request_total{job="kubernetes",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"2.."}[1h]))
+
+            '
+          record: code_verb:apiserver_request_total:increase1h
+        - expr: 'sum by (cluster, code, verb) (increase(apiserver_request_total{job="kubernetes",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"3.."}[1h]))
+
+            '
+          record: code_verb:apiserver_request_total:increase1h
+        - expr: 'sum by (cluster, code, verb) (increase(apiserver_request_total{job="kubernetes",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"4.."}[1h]))
+
+            '
+          record: code_verb:apiserver_request_total:increase1h
+        - expr: 'sum by (cluster, code, verb) (increase(apiserver_request_total{job="kubernetes",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
+
+            '
+          record: code_verb:apiserver_request_total:increase1h
+    - name: k8s.rules
+      rules:
+        - expr: "sum by (cluster, namespace, pod, container) (\n  irate(container_cpu_usage_seconds_total{job=\"\
+            kubelet\", metrics_path=\"/metrics/cadvisor\", image!=\"\"}[5m])\n) *\
+            \ on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace,\
+            \ pod) (\n  1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\
+            \"})\n)\n"
+          record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
+        - expr: "container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"\
+            /metrics/cadvisor\", image!=\"\"}\n* on (namespace, pod) group_left(node)\
+            \ topk by(namespace, pod) (1,\n  max by(namespace, pod, node) (kube_pod_info{node!=\"\
+            \"})\n)\n"
+          record: node_namespace_pod_container:container_memory_working_set_bytes
+        - expr: "container_memory_rss{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"\
+            , image!=\"\"}\n* on (namespace, pod) group_left(node) topk by(namespace,\
+            \ pod) (1,\n  max by(namespace, pod, node) (kube_pod_info{node!=\"\"})\n\
+            )\n"
+          record: node_namespace_pod_container:container_memory_rss
+        - expr: "container_memory_cache{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"\
+            , image!=\"\"}\n* on (namespace, pod) group_left(node) topk by(namespace,\
+            \ pod) (1,\n  max by(namespace, pod, node) (kube_pod_info{node!=\"\"})\n\
+            )\n"
+          record: node_namespace_pod_container:container_memory_cache
+        - expr: "container_memory_swap{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"\
+            , image!=\"\"}\n* on (namespace, pod) group_left(node) topk by(namespace,\
+            \ pod) (1,\n  max by(namespace, pod, node) (kube_pod_info{node!=\"\"})\n\
+            )\n"
+          record: node_namespace_pod_container:container_memory_swap
+        - expr: "kube_pod_container_resource_requests{resource=\"memory\",job=\"kube-state-metrics\"\
+            }  * on (namespace, pod, cluster)\ngroup_left() max by (namespace, pod)\
+            \ (\n  (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)\n)\n"
+          record: cluster:namespace:pod_memory:active:kube_pod_container_resource_requests
+        - expr: "sum by (namespace, cluster) (\n    sum by (namespace, pod, cluster)\
+            \ (\n        max by (namespace, pod, container, cluster) (\n         \
+            \ kube_pod_container_resource_requests{resource=\"memory\",job=\"kube-state-metrics\"\
+            }\n        ) * on(namespace, pod, cluster) group_left() max by (namespace,\
+            \ pod, cluster) (\n          kube_pod_status_phase{phase=~\"Pending|Running\"\
+            } == 1\n        )\n    )\n)\n"
+          record: namespace_memory:kube_pod_container_resource_requests:sum
+        - expr: "kube_pod_container_resource_requests{resource=\"cpu\",job=\"kube-state-metrics\"\
+            }  * on (namespace, pod, cluster)\ngroup_left() max by (namespace, pod)\
+            \ (\n  (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)\n)\n"
+          record: cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests
+        - expr: "sum by (namespace, cluster) (\n    sum by (namespace, pod, cluster)\
+            \ (\n        max by (namespace, pod, container, cluster) (\n         \
+            \ kube_pod_container_resource_requests{resource=\"cpu\",job=\"kube-state-metrics\"\
+            }\n        ) * on(namespace, pod, cluster) group_left() max by (namespace,\
+            \ pod, cluster) (\n          kube_pod_status_phase{phase=~\"Pending|Running\"\
+            } == 1\n        )\n    )\n)\n"
+          record: namespace_cpu:kube_pod_container_resource_requests:sum
+        - expr: "kube_pod_container_resource_limits{resource=\"memory\",job=\"kube-state-metrics\"\
+            }  * on (namespace, pod, cluster)\ngroup_left() max by (namespace, pod)\
+            \ (\n  (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)\n)\n"
+          record: cluster:namespace:pod_memory:active:kube_pod_container_resource_limits
+        - expr: "sum by (namespace, cluster) (\n    sum by (namespace, pod, cluster)\
+            \ (\n        max by (namespace, pod, container, cluster) (\n         \
+            \ kube_pod_container_resource_limits{resource=\"memory\",job=\"kube-state-metrics\"\
+            }\n        ) * on(namespace, pod, cluster) group_left() max by (namespace,\
+            \ pod, cluster) (\n          kube_pod_status_phase{phase=~\"Pending|Running\"\
+            } == 1\n        )\n    )\n)\n"
+          record: namespace_memory:kube_pod_container_resource_limits:sum
+        - expr: "kube_pod_container_resource_limits{resource=\"cpu\",job=\"kube-state-metrics\"\
+            }  * on (namespace, pod, cluster)\ngroup_left() max by (namespace, pod)\
+            \ (\n (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)\n )\n"
+          record: cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits
+        - expr: "sum by (namespace, cluster) (\n    sum by (namespace, pod, cluster)\
+            \ (\n        max by (namespace, pod, container, cluster) (\n         \
+            \ kube_pod_container_resource_limits{resource=\"cpu\",job=\"kube-state-metrics\"\
+            }\n        ) * on(namespace, pod, cluster) group_left() max by (namespace,\
+            \ pod, cluster) (\n          kube_pod_status_phase{phase=~\"Pending|Running\"\
+            } == 1\n        )\n    )\n)\n"
+          record: namespace_cpu:kube_pod_container_resource_limits:sum
+        - expr: "max by (cluster, namespace, workload, pod) (\n  label_replace(\n\
+            \    label_replace(\n      kube_pod_owner{job=\"kube-state-metrics\",\
+            \ owner_kind=\"ReplicaSet\"},\n      \"replicaset\", \"$1\", \"owner_name\"\
+            , \"(.*)\"\n    ) * on(replicaset, namespace) group_left(owner_name) topk\
+            \ by(replicaset, namespace) (\n      1, max by (replicaset, namespace,\
+            \ owner_name) (\n        kube_replicaset_owner{job=\"kube-state-metrics\"\
+            }\n      )\n    ),\n    \"workload\", \"$1\", \"owner_name\", \"(.*)\"\
+            \n  )\n)\n"
+          labels:
+            workload_type: deployment
+          record: namespace_workload_pod:kube_pod_owner:relabel
+        - expr: "max by (cluster, namespace, workload, pod) (\n  label_replace(\n\
+            \    kube_pod_owner{job=\"kube-state-metrics\", owner_kind=\"DaemonSet\"\
+            },\n    \"workload\", \"$1\", \"owner_name\", \"(.*)\"\n  )\n)\n"
+          labels:
+            workload_type: daemonset
+          record: namespace_workload_pod:kube_pod_owner:relabel
+        - expr: "max by (cluster, namespace, workload, pod) (\n  label_replace(\n\
+            \    kube_pod_owner{job=\"kube-state-metrics\", owner_kind=\"StatefulSet\"\
+            },\n    \"workload\", \"$1\", \"owner_name\", \"(.*)\"\n  )\n)\n"
+          labels:
+            workload_type: statefulset
+          record: namespace_workload_pod:kube_pod_owner:relabel
+    - name: kube-scheduler.rules
+      rules:
+        - expr: 'histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.99'
+          record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.99'
+          record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.99'
+          record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.9'
+          record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.9'
+          record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.9, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.9'
+          record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.5'
+          record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.5'
+          record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.5, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.5'
+          record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+    - name: node.rules
+      rules:
+        - expr: "topk by(namespace, pod) (1,\n  max by (node, namespace, pod) (\n\
+            \    label_replace(kube_pod_info{job=\"kube-state-metrics\",node!=\"\"\
+            }, \"pod\", \"$1\", \"pod\", \"(.*)\")\n))\n"
+          record: 'node_namespace_pod:kube_pod_info:'
+        - expr: "count by (cluster, node) (sum by (node, cpu) (\n  node_cpu_seconds_total{job=\"\
+            node-exporter\"}\n* on (namespace, pod) group_left(node)\n  topk by(namespace,\
+            \ pod) (1, node_namespace_pod:kube_pod_info:)\n))\n"
+          record: node:node_num_cpu:sum
+        - expr: "sum(\n  node_memory_MemAvailable_bytes{job=\"node-exporter\"} or\n\
+            \  (\n    node_memory_Buffers_bytes{job=\"node-exporter\"} +\n    node_memory_Cached_bytes{job=\"\
+            node-exporter\"} +\n    node_memory_MemFree_bytes{job=\"node-exporter\"\
+            } +\n    node_memory_Slab_bytes{job=\"node-exporter\"}\n  )\n) by (cluster)\n"
+          record: :node_memory_MemAvailable_bytes:sum
+    - name: kubelet.rules
+      rules:
+        - expr: 'histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m]))
+            by (instance, le) * on(instance) group_left(node) kubelet_node_name{job="expose-kubelets-metrics"})
+
+            '
+          labels:
+            quantile: '0.99'
+          record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.9, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m]))
+            by (instance, le) * on(instance) group_left(node) kubelet_node_name{job="expose-kubelets-metrics"})
+
+            '
+          labels:
+            quantile: '0.9'
+          record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.5, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m]))
+            by (instance, le) * on(instance) group_left(node) kubelet_node_name{job="expose-kubelets-metrics"})
+
+            '
+          labels:
+            quantile: '0.5'
+          record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: platform
+    role: alert-rules
+  name: platform-kube-prometheus-rules
+  namespace: syn-rancher-monitoring
+spec:
+  groups:
+    - name: general.rules
+      rules:
+        - alert: TargetDown
+          annotations:
+            description: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{
+              $labels.service }} targets in {{ $labels.namespace }} namespace are
+              down.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-targetdown
+            summary: One or more targets are unreachable.
+            syn_component: rancher-monitoring
+          expr: 100 * (count(up == 0) BY (job, namespace, service) / count(up) BY
+            (job, namespace, service)) > 10
+          for: 10m
+          labels:
+            severity: warning
+        - alert: Watchdog
+          annotations:
+            description: This is a dead mans switch meant to ensure that the entire
+              alerting pipeline is functional.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-watchdog
+            summary: Alerting dead mans switch
+            syn_component: rancher-monitoring
+          expr: vector(1)
+          labels:
+            heartbeat: 60s
+            severity: critical
+    - name: node-network
+      rules:
+        - alert: NodeNetworkInterfaceFlapping
+          annotations:
+            description: Network interface "{{ $labels.device }}" changing its up
+              status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod
+              }}
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodenetworkinterfaceflapping
+            summary: Network interface is often changing its status
+            syn_component: rancher-monitoring
+          expr: 'changes(node_network_up{job="node-exporter",device!~"veth.+"}[2m])
+            > 2
+
+            '
+          for: 2m
+          labels:
+            severity: warning
+    - name: kube-prometheus-node-recording.rules
+      rules:
+        - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m]))
+            BY (instance)
+          record: instance:node_cpu:rate:sum
+        - expr: sum(rate(node_network_receive_bytes_total[3m])) BY (instance)
+          record: instance:node_network_receive_bytes:rate:sum
+        - expr: sum(rate(node_network_transmit_bytes_total[3m])) BY (instance)
+          record: instance:node_network_transmit_bytes:rate:sum
+        - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m]))
+            WITHOUT (cpu, mode) / ON(instance) GROUP_LEFT() count(sum(node_cpu_seconds_total)
+            BY (instance, cpu)) BY (instance)
+          record: instance:node_cpu:ratio
+        - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m]))
+          record: cluster:node_cpu:sum_rate5m
+        - expr: cluster:node_cpu_seconds_total:rate5m / count(sum(node_cpu_seconds_total)
+            BY (instance, cpu))
+          record: cluster:node_cpu:ratio
+    - name: kube-prometheus-general.rules
+      rules:
+        - expr: count without(instance, pod, node) (up == 1)
+          record: count:up1
+        - expr: count without(instance, pod, node) (up == 0)
+          record: count:up0
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: alert-router
+    app.kubernetes.io/name: alertmanager
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.22.2
+    prometheus: platform
+    role: alert-rules
+  name: platform-alertmanager-rules
+  namespace: syn-rancher-monitoring
+spec:
+  groups:
+    - name: alertmanager.rules
+      rules:
+        - alert: AlertmanagerFailedReload
+          annotations:
+            description: Configuration has failed to load for {{ $labels.namespace
+              }}/{{ $labels.pod}}.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-alertmanagerfailedreload
+            summary: Reloading an Alertmanager configuration has failed.
+            syn_component: rancher-monitoring
+          expr: '# Without max_over_time, failed scrapes could create false negatives,
+            see
+
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0
+            for details.
+
+            max_over_time(alertmanager_config_last_reload_successful{job="alertmanager-platform",namespace="syn-rancher-monitoring"}[5m])
+            == 0
+
+            '
+          for: 10m
+          labels:
+            severity: critical
+        - alert: AlertmanagerMembersInconsistent
+          annotations:
+            description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has
+              only found {{ $value }} members of the {{$labels.job}} cluster.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-alertmanagermembersinconsistent
+            summary: A member of an Alertmanager cluster has not found all other cluster
+              members.
+            syn_component: rancher-monitoring
+          expr: "# Without max_over_time, failed scrapes could create false negatives,\
+            \ see\n# https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0\
+            \ for details.\n  max_over_time(alertmanager_cluster_members{job=\"alertmanager-platform\"\
+            ,namespace=\"syn-rancher-monitoring\"}[5m])\n< on (namespace,service)\
+            \ group_left\n  count by (namespace,service) (max_over_time(alertmanager_cluster_members{job=\"\
+            alertmanager-platform\",namespace=\"syn-rancher-monitoring\"}[5m]))\n"
+          for: 15m
+          labels:
+            severity: critical
+        - alert: AlertmanagerFailedToSendAlerts
+          annotations:
+            description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed
+              to send {{ $value | humanizePercentage }} of notifications to {{ $labels.integration
+              }}.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-alertmanagerfailedtosendalerts
+            summary: An Alertmanager instance failed to send notifications.
+            syn_component: rancher-monitoring
+          expr: "(\n  rate(alertmanager_notifications_failed_total{job=\"alertmanager-platform\"\
+            ,namespace=\"syn-rancher-monitoring\"}[5m])\n/\n  rate(alertmanager_notifications_total{job=\"\
+            alertmanager-platform\",namespace=\"syn-rancher-monitoring\"}[5m])\n)\n\
+            > 0.01\n"
+          for: 5m
+          labels:
+            severity: warning
+        - alert: AlertmanagerClusterFailedToSendAlerts
+          annotations:
+            description: The minimum notification failure rate to {{ $labels.integration
+              }} sent from any instance in the {{$labels.job}} cluster is {{ $value
+              | humanizePercentage }}.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-alertmanagerclusterfailedtosendalerts
+            summary: All Alertmanager instances in a cluster failed to send notifications
+              to a critical integration.
+            syn_component: rancher-monitoring
+          expr: "min by (namespace,service, integration) (\n  rate(alertmanager_notifications_failed_total{job=\"\
+            alertmanager-platform\",namespace=\"syn-rancher-monitoring\", integration=~`.*`}[5m])\n\
+            /\n  rate(alertmanager_notifications_total{job=\"alertmanager-platform\"\
+            ,namespace=\"syn-rancher-monitoring\", integration=~`.*`}[5m])\n)\n> 0.01\n"
+          for: 5m
+          labels:
+            severity: critical
+        - alert: AlertmanagerClusterFailedToSendAlerts
+          annotations:
+            description: The minimum notification failure rate to {{ $labels.integration
+              }} sent from any instance in the {{$labels.job}} cluster is {{ $value
+              | humanizePercentage }}.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-alertmanagerclusterfailedtosendalerts
+            summary: All Alertmanager instances in a cluster failed to send notifications
+              to a non-critical integration.
+            syn_component: rancher-monitoring
+          expr: "min by (namespace,service, integration) (\n  rate(alertmanager_notifications_failed_total{job=\"\
+            alertmanager-platform\",namespace=\"syn-rancher-monitoring\", integration!~`.*`}[5m])\n\
+            /\n  rate(alertmanager_notifications_total{job=\"alertmanager-platform\"\
+            ,namespace=\"syn-rancher-monitoring\", integration!~`.*`}[5m])\n)\n> 0.01\n"
+          for: 5m
+          labels:
+            severity: warning
+        - alert: AlertmanagerConfigInconsistent
+          annotations:
+            description: Alertmanager instances within the {{$labels.job}} cluster
+              have different configurations.
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-alertmanagerconfiginconsistent
+            summary: Alertmanager instances within the same cluster have different
+              configurations.
+            syn_component: rancher-monitoring
+          expr: "count by (namespace,service) (\n  count_values by (namespace,service)\
+            \ (\"config_hash\", alertmanager_config_hash{job=\"alertmanager-platform\"\
+            ,namespace=\"syn-rancher-monitoring\"})\n)\n!= 1\n"
+          for: 20m
+          labels:
+            severity: critical
+        - alert: AlertmanagerClusterDown
+          annotations:
+            description: '{{ $value | humanizePercentage }} of Alertmanager instances
+              within the {{$labels.job}} cluster have been up for less than half of
+              the last 5m.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-alertmanagerclusterdown
+            summary: Half or more of the Alertmanager instances within the same cluster
+              are down.
+            syn_component: rancher-monitoring
+          expr: "(\n  count by (namespace,service) (\n    avg_over_time(up{job=\"\
+            alertmanager-platform\",namespace=\"syn-rancher-monitoring\"}[5m]) < 0.5\n\
+            \  )\n/\n  count by (namespace,service) (\n    up{job=\"alertmanager-platform\"\
+            ,namespace=\"syn-rancher-monitoring\"}\n  )\n)\n>= 0.5\n"
+          for: 5m
+          labels:
+            severity: critical
+        - alert: AlertmanagerClusterCrashlooping
+          annotations:
+            description: '{{ $value | humanizePercentage }} of Alertmanager instances
+              within the {{$labels.job}} cluster have restarted at least 5 times in
+              the last 10m.'
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-alertmanagerclustercrashlooping
+            summary: Half or more of the Alertmanager instances within the same cluster
+              are crashlooping.
+            syn_component: rancher-monitoring
+          expr: "(\n  count by (namespace,service) (\n    changes(process_start_time_seconds{job=\"\
+            alertmanager-platform\",namespace=\"syn-rancher-monitoring\"}[10m]) >\
+            \ 4\n  )\n/\n  count by (namespace,service) (\n    up{job=\"alertmanager-platform\"\
+            ,namespace=\"syn-rancher-monitoring\"}\n  )\n)\n>= 0.5\n"
+          for: 5m
+          labels:
+            severity: critical

--- a/tests/kubernetes-1.21.yml
+++ b/tests/kubernetes-1.21.yml
@@ -1,0 +1,3 @@
+parameters:
+  rancher_monitoring:
+    cluster_kubernetes_version: '1.21'


### PR DESCRIPTION
We parse `cluster_kubernetes_version` and use the resulting minor version to determine which import path to use for kubernetes-mixin's `add-runbook-links.libsonnet`.

We also add an additional test case for K8s 1.21, so we cover both import paths in the tests.

Fixes #55 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
