### PR TITLE
Allow appending relabel configs to federation jobs

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -90,6 +90,7 @@ parameters:
       interval: '10s'
       scrape_timeout: '10s'
       jobs: ${rancher_monitoring:_federation_job_map:${rancher_monitoring:rancher_monitoring_version}}
+      extra_metric_relabel_configs: []
 
     alerts:
       namespaceSelector: namespace=~"default|((kube|syn|cattle).*)"

--- a/component/federation.jsonnet
+++ b/component/federation.jsonnet
@@ -9,6 +9,7 @@ local federation_interval = params.federation.interval;
 // "interval" and "scrape_timeout" are strings, so we can't do any meaningful
 // comparison/sanity checks without parsing them, which would be overkill.
 local federation_scrape_timeout = params.federation.scrape_timeout;
+local extra_metric_relabel_configs = params.federation.extra_metric_relabel_configs;
 
 local scrape_config = kube.Secret('additional-scrape-configs') {
   metadata+: {
@@ -82,7 +83,7 @@ local scrape_config = kube.Secret('additional-scrape-configs') {
             action: 'labeldrop',
             regex: '(__tmp|exported)_namespace',
           },
-        ],
+        ] + extra_metric_relabel_configs,
       },
     ]),
   },

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -189,11 +189,14 @@ default::
 ----
 interval: 10s
 scrape_timeout: 10s
+extra_metric_relabel_configs: []
 ----
 
 Configure the scrape interval and timeout for the Prometheus job which federates metrics from the Rancher Prometheus instance in `cattle-prometheus`.
 
 Users should ensure that the `scrape_timeout` is lower than the `interval`, as there's no validation logic in the component.
+
+`extra_metric_relabel_configs` allwos appending additional relabel configs to the federation job.
 
 
 == `alerts.namespaceSelector`


### PR DESCRIPTION
In order to drop some expensive metric we want to inject some relabel configs via tenant repos.

This change allows user to append their own relabel configs.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.
