### PR TITLE
Replace removed `app` label for alertmanager selector

### DIFF
--- a/component/alertmanager.jsonnet
+++ b/component/alertmanager.jsonnet
@@ -62,7 +62,7 @@ local service = kube.Service(name) {
     ],
     selector: {
       alertmanager: instance,
-      app: 'alertmanager',
+      'app.kubernetes.io/name': 'alertmanager',
     },
     sessionAffinity: 'ClientIP',
   },

--- a/docs/modules/ROOT/pages/how-tos/upgrade-4.x-to-5.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-4.x-to-5.x.adoc
@@ -1,0 +1,8 @@
+= Upgrade from 4.x to 5.x
+
+This guide describes the steps to perform an upgrade of the component from version 4.x to 5.x.
+
+[WARNING]
+====
+The 5.x version changes the selector for alertmanager. The new selector won't work for Kubernetes versions prior to 1.20 anymore.
+Therefore, before updating to version 5.x of this module, make sure to upgrade your cluster to at least 1.20.

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,2 +1,3 @@
 * xref:index.adoc[Home]
 * xref:references/parameters.adoc[Parameters]
+* xref:how-tos/upgrade-4.x-to-5.x.adoc[Upgrade 4.x to 5.x]

--- a/tests/golden/defaults/rancher-monitoring/rancher-monitoring/02_alertmanager.yaml
+++ b/tests/golden/defaults/rancher-monitoring/rancher-monitoring/02_alertmanager.yaml
@@ -49,7 +49,7 @@ spec:
       targetPort: web
   selector:
     alertmanager: platform
-    app: alertmanager
+    app.kubernetes.io/name: alertmanager
   sessionAffinity: ClientIP
   type: ClusterIP
 ---

--- a/tests/golden/kubernetes-1.21/rancher-monitoring/rancher-monitoring/02_alertmanager.yaml
+++ b/tests/golden/kubernetes-1.21/rancher-monitoring/rancher-monitoring/02_alertmanager.yaml
@@ -49,7 +49,7 @@ spec:
       targetPort: web
   selector:
     alertmanager: platform
-    app: alertmanager
+    app.kubernetes.io/name: alertmanager
   sessionAffinity: ClientIP
   type: ClusterIP
 ---

--- a/tests/golden/kubernetes-1.22/rancher-monitoring/rancher-monitoring/02_alertmanager.yaml
+++ b/tests/golden/kubernetes-1.22/rancher-monitoring/rancher-monitoring/02_alertmanager.yaml
@@ -49,7 +49,7 @@ spec:
       targetPort: web
   selector:
     alertmanager: platform
-    app: alertmanager
+    app.kubernetes.io/name: alertmanager
   sessionAffinity: ClientIP
   type: ClusterIP
 ---

--- a/tests/golden/kubernetes-1.23/rancher-monitoring/rancher-monitoring/02_alertmanager.yaml
+++ b/tests/golden/kubernetes-1.23/rancher-monitoring/rancher-monitoring/02_alertmanager.yaml
@@ -49,7 +49,7 @@ spec:
       targetPort: web
   selector:
     alertmanager: platform
-    app: alertmanager
+    app.kubernetes.io/name: alertmanager
   sessionAffinity: ClientIP
   type: ClusterIP
 ---


### PR DESCRIPTION
The `app` label has been removed from the most recent alertmanager version and therefore the service doesn't match anymore with the labels on the pods.

We replace the selector with a new label that is present on older and newer versions of alertmanager

Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>




## Checklist

- [ ] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
